### PR TITLE
Make requestABIId omitempty

### DIFF
--- a/internal/messages/messages.go
+++ b/internal/messages/messages.go
@@ -69,7 +69,7 @@ type ReplyHeaders struct {
 	Elapsed   float64 `json:"timeElapsed"`
 	ReqOffset string  `json:"requestOffset"`
 	ReqID     string  `json:"requestId"`
-	ReqABIID  string  `json:"requestABIId"`
+	ReqABIID  string  `json:"requestABIId,omitempty"`
 }
 
 // ReplyWithHeaders gives common access the reply headers


### PR DESCRIPTION
Two small observations in e2e testing of #159 fix:
- `requestABIId` does not have `omitempty`
  - Change made here
-  Would be helpful to fill this in, for the case we generated the ABI ID from the request ID, to make it clear we did that
  - This is actually really hard, due to where it's assigned. So suggesting we do not action this.