### PR TITLE
Create tagged image when publishing a release

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+  release:
+    types:
+      - published
 
 jobs:
   docker:
@@ -13,8 +16,12 @@ jobs:
 
       - name: Build
         run: docker build -t ghcr.io/hyperledger/firefly-ethconnect:latest .
-
-      - name: Push
+      
+      - name: Tag release
+        if: github.event_name == 'release' && github.event.action == 'published'
+        run: docker tag ghcr.io/hyperledger/firefly-ethconnect:latest ghcr.io/hyperledger/firefly-ethconnect:$GITHUB_REF
+      
+      - name: Push docker image
         run: |
           echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
-          docker push ghcr.io/hyperledger/firefly-ethconnect:latest
+          docker push -a ghcr.io/hyperledger/firefly-ethconnect


### PR DESCRIPTION
This GitHub action change should add an additional tag to the docker image when a new release is published. The image will be tagged with whatever the name of the release is. This will also update the `latest` image as well, though I'm open to feedback if we don't think that's a good idea. The question is, what does "latest" actually mean? Is it the most recently built docker image? Or is it the newest commit that has been merged into `main`?