### PR TITLE
Avoid holding batchCond while dispatching updateInterrupt

### DIFF
--- a/internal/events/eventstream.go
+++ b/internal/events/eventstream.go
@@ -541,11 +541,11 @@ func (a *eventStream) batchProcessor() {
 		a.batchCond.L.Lock()
 		for !a.suspendOrStop() && a.batchQueue.Len() == 0 {
 			if a.updateInProgress {
+				a.batchCond.L.Unlock()
 				<-a.updateInterrupt
 				// we were notified by the caller about an ongoing update, return
 				log.Infof("%s: Notified of an ongoing stream update, exiting batch processor", a.spec.ID)
 				a.updateWG.Done() //Not moving this to a 'defer' since we need to unlock after calling Done()
-				a.batchCond.L.Unlock()
 				return
 			} else {
 				a.batchCond.Wait()

--- a/internal/events/eventstream.go
+++ b/internal/events/eventstream.go
@@ -545,7 +545,7 @@ func (a *eventStream) batchProcessor() {
 				<-a.updateInterrupt
 				// we were notified by the caller about an ongoing update, return
 				log.Infof("%s: Notified of an ongoing stream update, exiting batch processor", a.spec.ID)
-				a.updateWG.Done() //Not moving this to a 'defer' since we need to unlock after calling Done()
+				a.updateWG.Done()
 				return
 			} else {
 				a.batchCond.Wait()


### PR DESCRIPTION
In #162 there is the following deadlock:

### Deadlock investigation

Batch processor trying to notify eventPoller to stop using `updateInterrupt`:
```
goroutine 547 [chan receive]:
github.com/hyperledger/firefly-ethconnect/internal/events.(*eventStream).batchProcessor(0xc0001be160)
	/ethconnect/internal/events/eventstream.go:544 +0x11b
created by github.com/hyperledger/firefly-ethconnect/internal/events.(*eventStream).startEventHandlers
	/ethconnect/internal/events/eventstream.go:209 +0x10c
```
https://github.com/hyperledger/firefly-ethconnect/blob/d686811c70f27d063730660e411185095fe7da1b/internal/events/eventstream.go#L544

Event poller trying to obtain the `batchCond`:
```
goroutine 546 [semacquire]:
sync.runtime_SemacquireMutex(0xc000028334, 0xbc8800, 0x1)
	/usr/local/go/src/runtime/sema.go:71 +0x47
sync.(*Mutex).lockSlow(0xc000028330)
	/usr/local/go/src/sync/mutex.go:138 +0x105
sync.(*Mutex).Lock(0xc000028330)
	/usr/local/go/src/sync/mutex.go:81 +0x47
github.com/hyperledger/firefly-ethconnect/internal/events.(*eventStream).isBlocked(0xc0001be160, 0xc000292030)
	/ethconnect/internal/events/eventstream.go:356 +0x5c
github.com/hyperledger/firefly-ethconnect/internal/events.(*eventStream).eventPoller(0xc0001be160)
	/ethconnect/internal/events/eventstream.go:393 +0xd85
created by github.com/hyperledger/firefly-ethconnect/internal/events.(*eventStream).startEventHandlers
	/ethconnect/internal/events/eventstream.go:207 +0xcc
```
https://github.com/hyperledger/firefly-ethconnect/blob/d686811c70f27d063730660e411185095fe7da1b/internal/events/eventstream.go#L356
... called from this loop:
https://github.com/hyperledger/firefly-ethconnect/blob/d686811c70f27d063730660e411185095fe7da1b/internal/events/eventstream.go#L393
... which is where we would pull from the `updateInterrupt`

### Proposed fix

Release the `batchCond` lock, before consuming from the `updateInterrupt` channel