### PR TITLE
Fix use of GITHUB_REF in docker build

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Build
-        run: docker build -t ghcr.io/hyperledger/firefly-ethconnect:$GITHUB_REF .
+        run: docker build -t ghcr.io/hyperledger/firefly-ethconnect:${GITHUB_REF##*/} .
       
       - name: Tag release
         if: github.event.action == 'published'
@@ -20,7 +20,7 @@ jobs:
       - name: Push docker image
         run: |
           echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
-          docker push ghcr.io/hyperledger/firefly-ethconnect:$GITHUB_REF
+          docker push ghcr.io/hyperledger/firefly-ethconnect:${GITHUB_REF##*/}
       
       - name: Push latest tag
         if: github.event.action == 'published'


### PR DESCRIPTION
Third time's the charm, right?

This should fix the fact that (despite what GitHub's documentation says) `GITHUB_REF` includes `refs/tags/` before the actual tag name. Using shell expansion, we can grab just the last part of the variable.

I tested the shell expansion locally and it seems to do the trick:
```
➜  ~ export GITHUB_REF="refs/tags/3.0.1"
➜  ~ echo $GITHUB_REF
refs/tags/3.0.1
➜  ~ echo ${GITHUB_REF##*/}
3.0.1
```