### PR TITLE
Fix tagging of latest image on release

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,7 +15,7 @@ jobs:
       
       - name: Tag release
         if: github.event.action == 'published'
-        run: docker tag ghcr.io/hyperledger/firefly-ethconnect:latest ghcr.io/hyperledger/firefly-ethconnect:latest
+        run: docker tag ghcr.io/hyperledger/firefly-ethconnect:${GITHUB_REF##*/} ghcr.io/hyperledger/firefly-ethconnect:latest
       
       - name: Push docker image
         run: |


### PR DESCRIPTION
This should fix the current problem with tagging latest on a release build
```
Run docker tag ghcr.io/hyperledger/firefly-ethconnect:latest ghcr.io/hyperledger/firefly-ethconnect:latest
  docker tag ghcr.io/hyperledger/firefly-ethconnect:latest ghcr.io/hyperledger/firefly-ethconnect:latest
  shell: /usr/bin/bash -e {0}
Error response from daemon: No such image: ghcr.io/hyperledger/firefly-ethconnect:latest
```