### PR TITLE
Fix release action

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,7 +2,7 @@ name: Docker
 
 on:
   release:
-    types: [published, prereleased]
+    types: [released, prereleased]
 
 jobs:
   docker:
@@ -14,7 +14,7 @@ jobs:
         run: docker build -t ghcr.io/hyperledger/firefly-ethconnect:${GITHUB_REF##*/} .
       
       - name: Tag release
-        if: github.event.action == 'published'
+        if: github.event.action == 'released'
         run: docker tag ghcr.io/hyperledger/firefly-ethconnect:${GITHUB_REF##*/} ghcr.io/hyperledger/firefly-ethconnect:latest
       
       - name: Push docker image
@@ -23,7 +23,7 @@ jobs:
           docker push ghcr.io/hyperledger/firefly-ethconnect:${GITHUB_REF##*/}
       
       - name: Push latest tag
-        if: github.event.action == 'published'
+        if: github.event.action == 'released'
         run: |
           echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
           docker push ghcr.io/hyperledger/firefly-ethconnect:latest


### PR DESCRIPTION
This will prevent duplicate build tasks when creating pre-release versions, as well as `latest` getting set to a pre-release version.