### PR TITLE
Add error codes to all ethconnect errors

### DIFF
--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -51,7 +51,7 @@ func TestAccessToken(t *testing.T) {
 	assert.Equal("", GetAccessToken(context.Background()))
 
 	_, err = WithAuthContext(context.Background(), "badone")
-	assert.EqualError(err, "badness")
+	assert.Regexp("badness", err)
 
 	RegisterSecurityModule(nil)
 }
@@ -63,13 +63,13 @@ func TestAuthRPC(t *testing.T) {
 
 	RegisterSecurityModule(&authtest.TestSecurityModule{})
 
-	assert.EqualError(AuthRPC(context.Background(), "anything"), "No auth context")
+	assert.Regexp("No auth context", AuthRPC(context.Background(), "anything"))
 
 	assert.NoError(AuthRPC(NewSystemAuthContext(), "anything"))
 
 	ctx, _ := WithAuthContext(context.Background(), "testat")
 	assert.NoError(AuthRPC(ctx, "testrpc"))
-	assert.EqualError(AuthRPC(ctx, "anything"), "badness")
+	assert.Regexp("badness", AuthRPC(ctx, "anything"))
 
 	RegisterSecurityModule(nil)
 
@@ -82,13 +82,13 @@ func TestAuthRPCSubscribe(t *testing.T) {
 
 	RegisterSecurityModule(&authtest.TestSecurityModule{})
 
-	assert.EqualError(AuthRPCSubscribe(context.Background(), "anything", nil), "No auth context")
+	assert.Regexp("No auth context", AuthRPCSubscribe(context.Background(), "anything", nil))
 
 	assert.NoError(AuthRPCSubscribe(NewSystemAuthContext(), "anything", nil))
 
 	ctx, _ := WithAuthContext(context.Background(), "testat")
 	assert.NoError(AuthRPCSubscribe(ctx, "testns", nil))
-	assert.EqualError(AuthRPCSubscribe(ctx, "anything", nil), "badness")
+	assert.Regexp("badness", AuthRPCSubscribe(ctx, "anything", nil))
 
 	RegisterSecurityModule(nil)
 
@@ -101,7 +101,7 @@ func TestAuthEventStreams(t *testing.T) {
 
 	RegisterSecurityModule(&authtest.TestSecurityModule{})
 
-	assert.EqualError(AuthEventStreams(context.Background()), "No auth context")
+	assert.Regexp("No auth context", AuthEventStreams(context.Background()))
 
 	assert.NoError(AuthEventStreams(NewSystemAuthContext()))
 
@@ -119,7 +119,7 @@ func TestAuthListAsyncReplies(t *testing.T) {
 
 	RegisterSecurityModule(&authtest.TestSecurityModule{})
 
-	assert.EqualError(AuthListAsyncReplies(context.Background()), "No auth context")
+	assert.Regexp("No auth context", AuthListAsyncReplies(context.Background()))
 
 	assert.NoError(AuthListAsyncReplies(NewSystemAuthContext()))
 
@@ -137,7 +137,7 @@ func TestAuthReadAsyncReplyByUUID(t *testing.T) {
 
 	RegisterSecurityModule(&authtest.TestSecurityModule{})
 
-	assert.EqualError(AuthReadAsyncReplyByUUID(context.Background()), "No auth context")
+	assert.Regexp("No auth context", AuthReadAsyncReplyByUUID(context.Background()))
 
 	assert.NoError(AuthReadAsyncReplyByUUID(NewSystemAuthContext()))
 

--- a/internal/contractgateway/rest2eth_test.go
+++ b/internal/contractgateway/rest2eth_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/hyperledger/firefly-ethconnect/internal/auth"
 	"github.com/hyperledger/firefly-ethconnect/internal/auth/authtest"
 	"github.com/hyperledger/firefly-ethconnect/internal/contractregistry"
+	"github.com/hyperledger/firefly-ethconnect/internal/errors"
 	"github.com/hyperledger/firefly-ethconnect/internal/eth"
 	"github.com/hyperledger/firefly-ethconnect/internal/ethbind"
 	"github.com/hyperledger/firefly-ethconnect/internal/events"
@@ -747,7 +748,7 @@ func TestSendTransactionSyncFail(t *testing.T) {
 	router.ServeHTTP(res, req)
 
 	assert.Equal(500, res.Result().StatusCode)
-	reply := restErrMsg{}
+	reply := errors.RESTError{}
 	err := json.NewDecoder(res.Result().Body).Decode(&reply)
 	assert.NoError(err)
 	assert.Equal("pop", reply.Message)
@@ -776,7 +777,7 @@ func TestSendTransactionAsyncFail(t *testing.T) {
 	router.ServeHTTP(res, req)
 
 	assert.Equal(500, res.Result().StatusCode)
-	reply := restErrMsg{}
+	reply := errors.RESTError{}
 	err := json.NewDecoder(res.Result().Body).Decode(&reply)
 	assert.NoError(err)
 	assert.Equal("pop", reply.Message)
@@ -807,7 +808,7 @@ func TestDeployContractAsyncFail(t *testing.T) {
 	router.ServeHTTP(res, req)
 
 	assert.Equal(500, res.Result().StatusCode)
-	reply := restErrMsg{}
+	reply := errors.RESTError{}
 	err := json.NewDecoder(res.Result().Body).Decode(&reply)
 	assert.NoError(err)
 	assert.Equal("pop", reply.Message)
@@ -836,7 +837,7 @@ func TestSendTransactionAsyncBadMethod(t *testing.T) {
 	router.ServeHTTP(res, req)
 
 	assert.Equal(500, res.Result().StatusCode)
-	reply := restErrMsg{}
+	reply := errors.RESTError{}
 	err := json.NewDecoder(res.Result().Body).Decode(&reply)
 	assert.NoError(err)
 	assert.Equal("pop", reply.Message)
@@ -866,7 +867,7 @@ func TestSendTransactionBadContract(t *testing.T) {
 	router.ServeHTTP(res, req)
 
 	assert.Equal(500, res.Result().StatusCode)
-	reply := restErrMsg{}
+	reply := errors.RESTError{}
 	err := json.NewDecoder(res.Result().Body).Decode(&reply)
 	assert.NoError(err)
 	assert.Equal("pop", reply.Message)
@@ -893,7 +894,7 @@ func TestSendTransactionUnknownRegisteredName(t *testing.T) {
 	router.ServeHTTP(res, req)
 
 	assert.Equal(404, res.Result().StatusCode)
-	reply := restErrMsg{}
+	reply := errors.RESTError{}
 	err := json.NewDecoder(res.Result().Body).Decode(&reply)
 	assert.NoError(err)
 	assert.Equal("unregistered", reply.Message)
@@ -919,7 +920,7 @@ func TestSendTransactionContractNotFound(t *testing.T) {
 	router.ServeHTTP(res, req)
 
 	assert.Equal(404, res.Result().StatusCode)
-	reply := restErrMsg{}
+	reply := errors.RESTError{}
 	err := json.NewDecoder(res.Result().Body).Decode(&reply)
 	assert.NoError(err)
 	assert.Equal("not found", reply.Message)
@@ -948,10 +949,10 @@ func TestSendTransactionMissingContract(t *testing.T) {
 	router.ServeHTTP(res, req)
 
 	assert.Equal(400, res.Result().StatusCode)
-	reply := restErrMsg{}
+	reply := errors.RESTError{}
 	err := json.NewDecoder(res.Result().Body).Decode(&reply)
 	assert.NoError(err)
-	assert.Equal("Please specify a valid address in the 'fly-from' query string parameter or x-firefly-from HTTP header", reply.Message)
+	assert.Regexp("Please specify a valid address in the 'fly-from' query string parameter or x-firefly-from HTTP header", reply.Message)
 
 	mcr.AssertExpectations(t)
 }
@@ -992,10 +993,10 @@ func TestSendTransactionBadMethodABI(t *testing.T) {
 	res := httptest.NewRecorder()
 	router.ServeHTTP(res, req)
 	assert.Equal(400, res.Result().StatusCode)
-	reply := restErrMsg{}
+	reply := errors.RESTError{}
 	err := json.NewDecoder(res.Result().Body).Decode(&reply)
 	assert.NoError(err)
-	assert.Equal("Invalid method 'badmethod' in ABI: unsupported arg type: badness", reply.Message)
+	assert.Regexp("Invalid method 'badmethod' in ABI: unsupported arg type: badness", reply.Message)
 
 	mcr.AssertExpectations(t)
 }
@@ -1036,10 +1037,10 @@ func TestSendTransactionBadEventABI(t *testing.T) {
 	res := httptest.NewRecorder()
 	router.ServeHTTP(res, req)
 	assert.Equal(400, res.Result().StatusCode)
-	reply := restErrMsg{}
+	reply := errors.RESTError{}
 	err := json.NewDecoder(res.Result().Body).Decode(&reply)
 	assert.NoError(err)
-	assert.Equal("Invalid event 'badevent' in ABI: unsupported arg type: badness", reply.Message)
+	assert.Regexp("Invalid event 'badevent' in ABI: unsupported arg type: badness", reply.Message)
 
 	mcr.AssertExpectations(t)
 }
@@ -1078,10 +1079,10 @@ func TestSendTransactionBadConstructorABI(t *testing.T) {
 	res := httptest.NewRecorder()
 	router.ServeHTTP(res, req)
 	assert.Equal(400, res.Result().StatusCode)
-	reply := restErrMsg{}
+	reply := errors.RESTError{}
 	err := json.NewDecoder(res.Result().Body).Decode(&reply)
 	assert.NoError(err)
-	assert.Equal("Invalid method 'constructor' in ABI: unsupported arg type: badness", reply.Message)
+	assert.Regexp("Invalid method 'constructor' in ABI: unsupported arg type: badness", reply.Message)
 
 	mcr.AssertExpectations(t)
 }
@@ -1182,10 +1183,10 @@ func TestSendTransactionBadFrom(t *testing.T) {
 	router.ServeHTTP(res, req)
 
 	assert.Equal(404, res.Result().StatusCode)
-	reply := restErrMsg{}
+	reply := errors.RESTError{}
 	err := json.NewDecoder(res.Result().Body).Decode(&reply)
 	assert.NoError(err)
-	assert.Equal("From Address must be a 40 character hex string (0x prefix is optional)", reply.Message)
+	assert.Regexp("From Address must be a 40 character hex string \\(0x prefix is optional\\)", reply.Message)
 
 	mcr.AssertExpectations(t)
 }
@@ -1213,7 +1214,7 @@ func TestSendTransactionInvalidContract(t *testing.T) {
 	router.ServeHTTP(res, req)
 
 	assert.Equal(404, res.Result().StatusCode)
-	reply := restErrMsg{}
+	reply := errors.RESTError{}
 	err := json.NewDecoder(res.Result().Body).Decode(&reply)
 	assert.NoError(err)
 	assert.Equal("pop", reply.Message)
@@ -1251,7 +1252,7 @@ func TestDeployContractInvalidABI(t *testing.T) {
 	router.ServeHTTP(res, req)
 
 	assert.Equal(500, res.Result().StatusCode)
-	reply := restErrMsg{}
+	reply := errors.RESTError{}
 	err := json.NewDecoder(res.Result().Body).Decode(&reply)
 	assert.NoError(err)
 	assert.Equal("pop", reply.Message)
@@ -1285,10 +1286,10 @@ func TestSendTransactionInvalidMethod(t *testing.T) {
 	router.ServeHTTP(res, req)
 
 	assert.Equal(404, res.Result().StatusCode)
-	reply := restErrMsg{}
+	reply := errors.RESTError{}
 	err := json.NewDecoder(res.Result().Body).Decode(&reply)
 	assert.NoError(err)
-	assert.Equal("Method or Event 'shazaam' is not declared in the ABI of contract '567a417717cb6c59ddc1035705f02c0fd1ab1872'", reply.Message)
+	assert.Regexp("Method or Event 'shazaam' is not declared in the ABI of contract '567a417717cb6c59ddc1035705f02c0fd1ab1872'", reply.Message)
 
 	mcr.AssertExpectations(t)
 }
@@ -1372,10 +1373,10 @@ func TestSendTransactionMissingParam(t *testing.T) {
 	router.ServeHTTP(res, req)
 
 	assert.Equal(400, res.Result().StatusCode)
-	reply := restErrMsg{}
+	reply := errors.RESTError{}
 	err := json.NewDecoder(res.Result().Body).Decode(&reply)
 	assert.NoError(err)
-	assert.Equal("Parameter 'i' of method 'set' was not specified in body or query parameters", reply.Message)
+	assert.Regexp("Parameter 'i' of method 'set' was not specified in body or query parameters", reply.Message)
 
 	mcr.AssertExpectations(t)
 }
@@ -1404,7 +1405,7 @@ func TestSendTransactionBadBody(t *testing.T) {
 	router.ServeHTTP(res, req)
 
 	assert.Equal(400, res.Result().StatusCode)
-	reply := restErrMsg{}
+	reply := errors.RESTError{}
 	err := json.NewDecoder(res.Result().Body).Decode(&reply)
 	assert.NoError(err)
 	assert.Regexp("Unable to parse as YAML or JSON", reply.Message)
@@ -1616,7 +1617,7 @@ func TestCallMethodFail(t *testing.T) {
 	router.ServeHTTP(res, req)
 
 	assert.Equal(500, res.Result().StatusCode)
-	reply := restErrMsg{}
+	reply := errors.RESTError{}
 	err := json.NewDecoder(res.Result().Body).Decode(&reply)
 	assert.NoError(err)
 	assert.Regexp("Call failed: pop", reply.Message)
@@ -1654,10 +1655,10 @@ func TestCallMethodViaABIBadAddress(t *testing.T) {
 	router.ServeHTTP(res, req)
 
 	assert.Equal(404, res.Result().StatusCode)
-	reply := restErrMsg{}
+	reply := errors.RESTError{}
 	err := json.NewDecoder(res.Result().Body).Decode(&reply)
 	assert.NoError(err)
-	assert.Equal("To Address must be a 40 character hex string (0x prefix is optional)", reply.Message)
+	assert.Regexp("To Address must be a 40 character hex string \\(0x prefix is optional\\)", reply.Message)
 
 	mcr.AssertExpectations(t)
 }
@@ -1681,10 +1682,10 @@ func TestSubscribeNoAddressNoSubMgr(t *testing.T) {
 	router.ServeHTTP(res, req)
 
 	assert.Equal(405, res.Result().StatusCode)
-	reply := restErrMsg{}
+	reply := errors.RESTError{}
 	err := json.NewDecoder(res.Result().Body).Decode(&reply)
 	assert.NoError(err)
-	assert.Equal("Event support is not configured on this gateway", reply.Message)
+	assert.Regexp("Event support is not configured on this gateway", reply.Message)
 
 	mcr.AssertExpectations(t)
 }
@@ -1708,10 +1709,10 @@ func TestSubscribeNoAddressUnknownEvent(t *testing.T) {
 	router.ServeHTTP(res, req)
 
 	assert.Equal(404, res.Result().StatusCode)
-	reply := restErrMsg{}
+	reply := errors.RESTError{}
 	err := json.NewDecoder(res.Result().Body).Decode(&reply)
 	assert.NoError(err)
-	assert.Equal("Event 'subscribe' is not declared in the ABI", reply.Message)
+	assert.Regexp("Event 'subscribe' is not declared in the ABI", reply.Message)
 
 	mcr.AssertExpectations(t)
 }
@@ -1736,10 +1737,10 @@ func TestSubscribeUnauthorized(t *testing.T) {
 	router.ServeHTTP(res, req)
 
 	assert.Equal(401, res.Result().StatusCode)
-	reply := restErrMsg{}
+	reply := errors.RESTError{}
 	err := json.NewDecoder(res.Result().Body).Decode(&reply)
 	assert.NoError(err)
-	assert.Equal("Unauthorized", reply.Message)
+	assert.Regexp(reply.Message, "Unauthorized")
 
 	auth.RegisterSecurityModule(nil)
 	mcr.AssertExpectations(t)
@@ -1762,10 +1763,10 @@ func TestSubscribeNoAddressMissingStream(t *testing.T) {
 	router.ServeHTTP(res, req)
 
 	assert.Equal(400, res.Result().StatusCode)
-	reply := restErrMsg{}
+	reply := errors.RESTError{}
 	err := json.NewDecoder(res.Result().Body).Decode(&reply)
 	assert.NoError(err)
-	assert.Equal("Must supply a 'stream' parameter in the body or query", reply.Message)
+	assert.Regexp(reply.Message, "Must supply a 'stream' parameter in the body or query")
 
 	mcr.AssertExpectations(t)
 }
@@ -1855,7 +1856,7 @@ func TestSubscribeWithAddressBadAddress(t *testing.T) {
 	router.ServeHTTP(res, req)
 
 	assert.Equal(404, res.Result().StatusCode)
-	reply := restErrMsg{}
+	reply := errors.RESTError{}
 	err := json.NewDecoder(res.Result().Body).Decode(&reply)
 	assert.NoError(err)
 	assert.Equal("unregistered", reply.Message)
@@ -1884,7 +1885,7 @@ func TestSubscribeWithAddressSubmgrFailure(t *testing.T) {
 	router.ServeHTTP(res, req)
 
 	assert.Equal(400, res.Result().StatusCode)
-	reply := restErrMsg{}
+	reply := errors.RESTError{}
 	err := json.NewDecoder(res.Result().Body).Decode(&reply)
 	assert.NoError(err)
 	assert.Equal("pop", reply.Message)

--- a/internal/contractgateway/smartcontractgw_test.go
+++ b/internal/contractgateway/smartcontractgw_test.go
@@ -357,6 +357,7 @@ func TestRegisterExistingContract(t *testing.T) {
 	json.NewDecoder(res.Body).Decode(&errBody)
 	assert.Equal(409, res.Code)
 	assert.Equal("Contract address 0123456789abcdef0123456789abcdef01234567 is already registered for name 'testcontract'", errBody["error"])
+	assert.Equal(errors.RESTGatewayFriendlyNameClash.Code(), errBody["code"])
 
 	req = httptest.NewRequest("GET", "/contracts/testcontract?swagger", bytes.NewReader([]byte{}))
 	res = httptest.NewRecorder()

--- a/internal/contractgateway/syncdispatcher_test.go
+++ b/internal/contractgateway/syncdispatcher_test.go
@@ -124,7 +124,7 @@ func TestDispatchSendTransactionBadUnmarshal(t *testing.T) {
 	r := &mockReplyProcessor{}
 	d.DispatchSendTransactionSync(context.Background(), sendTx, r)
 
-	assert.EqualError(processor.unmarshalErr, "Unexpected condition (message types do not match when processing)")
+	assert.Regexp("Unexpected condition \\(message types do not match when processing\\)", processor.unmarshalErr)
 }
 
 func TestDispatchSendTransactionError(t *testing.T) {
@@ -141,5 +141,5 @@ func TestDispatchSendTransactionError(t *testing.T) {
 	r := &mockReplyProcessor{}
 	d.DispatchSendTransactionSync(context.Background(), sendTx, r)
 
-	assert.EqualError(r.err, "TX hash1: pop")
+	assert.Regexp("TX hash1: pop", r.err)
 }

--- a/internal/contractregistry/contractstore_test.go
+++ b/internal/contractregistry/contractstore_test.go
@@ -161,7 +161,7 @@ func TestLoadDeployMsgRemoteLookupNotFound(t *testing.T) {
 		ABIType: LocalABI,
 		Name:    "abi1",
 	}, false)
-	assert.EqualError(err, "No ABI found with ID abi1")
+	assert.Regexp("No ABI found with ID abi1", err)
 }
 
 func TestStoreABIWriteFail(t *testing.T) {
@@ -242,7 +242,7 @@ func TestCheckNameAvailableRRDuplicate(t *testing.T) {
 	cs := NewContractStore(&ContractStoreConf{BaseURL: "http://localhost/api/v1"}, mrr)
 
 	err := cs.CheckNameAvailable("lobster", true)
-	assert.EqualError(err, "Contract address 12345 is already registered for name 'lobster'")
+	assert.Regexp("Contract address 12345 is already registered for name 'lobster'", err)
 }
 
 func TestCheckNameAvailableRRFail(t *testing.T) {
@@ -254,7 +254,7 @@ func TestCheckNameAvailableRRFail(t *testing.T) {
 	cs := NewContractStore(&ContractStoreConf{BaseURL: "http://localhost/api/v1"}, mrr)
 
 	err := cs.CheckNameAvailable("lobster", true)
-	assert.EqualError(err, "pop")
+	assert.Regexp("pop", err)
 }
 
 func TestBuildIndex(t *testing.T) {

--- a/internal/contractregistry/remoteregistry_test.go
+++ b/internal/contractregistry/remoteregistry_test.go
@@ -256,7 +256,7 @@ func TestRemoteRegistryRegisterNoInstanceURL(t *testing.T) {
 	rr := r.(*remoteRegistry)
 
 	err := rr.RegisterInstance("testid", "12345")
-	assert.EqualError(err, "No remote registry is configured")
+	assert.Regexp("No remote registry is configured", err)
 }
 
 func TestRemoteRegistryLoadFactoryMissingID(t *testing.T) {
@@ -282,7 +282,7 @@ func TestRemoteRegistryLoadFactoryMissingID(t *testing.T) {
 	rr := r.(*remoteRegistry)
 
 	_, err := rr.LoadFactoryForGateway("testid", false)
-	assert.EqualError(err, "'id' missing in Contract registry response")
+	assert.Regexp("'id' missing in Contract registry response", err)
 }
 
 func TestRemoteRegistryLoadFactoryMissingABI(t *testing.T) {
@@ -308,7 +308,7 @@ func TestRemoteRegistryLoadFactoryMissingABI(t *testing.T) {
 	rr := r.(*remoteRegistry)
 
 	_, err := rr.LoadFactoryForGateway("testid", false)
-	assert.EqualError(err, "'abi' missing in Contract registry response")
+	assert.Regexp("'abi' missing in Contract registry response", err)
 }
 
 func TestRemoteRegistryLoadFactoryBadABIJSON(t *testing.T) {
@@ -335,7 +335,7 @@ func TestRemoteRegistryLoadFactoryBadABIJSON(t *testing.T) {
 	rr := r.(*remoteRegistry)
 
 	_, err := rr.LoadFactoryForGateway("testid", false)
-	assert.EqualError(err, "Error processing contract registry response")
+	assert.Regexp("Error processing contract registry response", err)
 }
 
 func TestRemoteRegistryLoadFactoryMissingDevDoc(t *testing.T) {
@@ -362,7 +362,7 @@ func TestRemoteRegistryLoadFactoryMissingDevDoc(t *testing.T) {
 	rr := r.(*remoteRegistry)
 
 	_, err := rr.LoadFactoryForGateway("testid", false)
-	assert.EqualError(err, "'devdoc' missing in Contract registry response")
+	assert.Regexp("'devdoc' missing in Contract registry response", err)
 }
 
 func TestRemoteRegistryLoadFactoryBadDevDoc(t *testing.T) {
@@ -390,7 +390,7 @@ func TestRemoteRegistryLoadFactoryBadDevDoc(t *testing.T) {
 	rr := r.(*remoteRegistry)
 
 	_, err := rr.LoadFactoryForGateway("testid", false)
-	assert.EqualError(err, "'devdoc' not a string in Contract registry response")
+	assert.Regexp("'devdoc' not a string in Contract registry response", err)
 }
 
 func TestRemoteRegistryLoadFactoryEmptyBytecode(t *testing.T) {
@@ -419,7 +419,7 @@ func TestRemoteRegistryLoadFactoryEmptyBytecode(t *testing.T) {
 	rr := r.(*remoteRegistry)
 
 	_, err := rr.LoadFactoryForGateway("testid", false)
-	assert.EqualError(err, "'bin' empty (or null) in Contract registry response")
+	assert.Regexp("'bin' empty \\(or null\\) in Contract registry response", err)
 }
 
 func TestRemoteRegistryLoadFactoryBadBytecode(t *testing.T) {
@@ -448,7 +448,7 @@ func TestRemoteRegistryLoadFactoryBadBytecode(t *testing.T) {
 	rr := r.(*remoteRegistry)
 
 	_, err := rr.LoadFactoryForGateway("testid", false)
-	assert.EqualError(err, "Error processing contract registry response")
+	assert.Regexp("Error processing contract registry response", err)
 }
 
 func TestRemoteRegistryLoadFactoryErrorStatusGeneric(t *testing.T) {
@@ -471,7 +471,7 @@ func TestRemoteRegistryLoadFactoryErrorStatusGeneric(t *testing.T) {
 	rr := r.(*remoteRegistry)
 
 	_, err := rr.LoadFactoryForGateway("testid", false)
-	assert.EqualError(err, "Could not process Contract registry [500] response")
+	assert.Regexp("Could not process Contract registry \\[500\\] response", err)
 }
 
 func TestRemoteRegistryLoadFactoryErrorStatus(t *testing.T) {
@@ -495,7 +495,7 @@ func TestRemoteRegistryLoadFactoryErrorStatus(t *testing.T) {
 	rr := r.(*remoteRegistry)
 
 	_, err := rr.LoadFactoryForGateway("testid", false)
-	assert.EqualError(err, "Contract registry returned [500]: poof")
+	assert.Regexp("Contract registry returned \\[500\\]: poof", err)
 }
 
 func TestRemoteRegistryLoadFactoryNotFound(t *testing.T) {
@@ -543,7 +543,7 @@ func TestRemoteRegistryLoadFactoryBadBody(t *testing.T) {
 	rr := r.(*remoteRegistry)
 
 	_, err := rr.LoadFactoryForGateway("testid", false)
-	assert.EqualError(err, "Could not process Contract registry [200] response")
+	assert.Regexp("Could not process Contract registry \\[200\\] response", err)
 }
 
 func TestRemoteRegistryLoadFactoryNOOP(t *testing.T) {

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -16,462 +16,526 @@ package errors
 
 import (
 	"fmt"
-
-	"github.com/pkg/errors"
 )
 
-// ErrorID enumerates all errors in ethconnect.
-type ErrorID string
+var errDupCheck = map[int]bool{}
 
-const (
+type ErrorID interface {
+	Code() string
+}
+
+type errorID struct {
+	code  int
+	enMsg string
+}
+
+func (e *errorID) Code() string {
+	return fmt.Sprintf("FFEC%d", e.code)
+}
+
+func e(code int, enMsg string) ErrorID {
+	if _, ok := errDupCheck[code]; ok {
+		panic(fmt.Sprintf("Duplicate code %d: %s", code, enMsg))
+	}
+	if code < 100000 || code > 200000 {
+		panic(fmt.Sprintf("Invalid code %d: %s", code, enMsg))
+	}
+	e := &errorID{code, enMsg}
+	errDupCheck[code] = true
+	return e
+}
+
+var (
 
 	// AddressBookLookupBadURL we got back a bad URL from the remote address book after our REST call
-	AddressBookLookupBadURL = "Invalid URL obtained for address"
+	AddressBookLookupBadURL = e(100000, "Invalid URL obtained for address")
 	// AddressBookLookupBadHostsFile we have a custom hosts file for DNS resolution, but it cannot be processed
-	AddressBookLookupBadHostsFile = "Configuration problem (hosts file)"
+	AddressBookLookupBadHostsFile = e(100001, "Configuration problem (hosts file)")
 	// AddressBookLookupNotFound remote addressbook says no
-	AddressBookLookupNotFound = "Unknown address"
+	AddressBookLookupNotFound = e(100002, "Unknown address")
 
 	// ConfigFileReadFailed failed to read the server config file
-	ConfigFileReadFailed = "Failed to read %s: %s"
+	ConfigFileReadFailed = e(100003, "Failed to read %s: %s")
 	// CompilerVersionNotFound the runtime context of ethconnect has not been configured with a compiler for the requested version
-	CompilerVersionNotFound = "Could not find a configured compiler for requested Solidity major version %s.%s"
+	CompilerVersionNotFound = e(100004, "Could not find a configured compiler for requested Solidity major version %s.%s")
 	// CompilerVersionBadRequest the user requested a bad semver
-	CompilerVersionBadRequest = "Invalid Solidity version requested for compiler. Ensure the string starts with two dot separated numbers, such as 0.5"
+	CompilerVersionBadRequest = e(100005, "Invalid Solidity version requested for compiler. Ensure the string starts with two dot separated numbers, such as 0.5")
 	// CompilerFailedSolc compilation failure output from solc
-	CompilerFailedSolc = "Solidity compilation failed: solc: %v\n%s"
+	CompilerFailedSolc = e(100006, "Solidity compilation failed: solc: %v\n%s")
 	// CompilerOutputMissingContract the output from the compiler does not include the requested contract
-	CompilerOutputMissingContract = "Contract '%s' not found in Solidity source: %s"
+	CompilerOutputMissingContract = e(100007, "Contract '%s' not found in Solidity source: %s")
 	// CompilerOutputMultipleContracts need to select one
-	CompilerOutputMultipleContracts = "More than one contract in Solidity file, please set one to call: %s"
+	CompilerOutputMultipleContracts = e(100008, "More than one contract in Solidity file, please set one to call: %s")
 	// CompilerBytecodeInvalid hex output from compiler could not be parsed
-	CompilerBytecodeInvalid = "Decoding bytecode: %s"
+	CompilerBytecodeInvalid = e(100009, "Decoding bytecode: %s")
 	// CompilerBytecodeEmpty null result from succcessful compile in solc
-	CompilerBytecodeEmpty = "Specified contract compiled ok, but did not result in any bytecode: %s"
+	CompilerBytecodeEmpty = e(100010, "Specified contract compiled ok, but did not result in any bytecode: %s")
 	// CompilerABISerialize could not serialize the ABI output from solc
-	CompilerABISerialize = "Serializing ABI: %s"
+	CompilerABISerialize = e(100011, "Serializing ABI: %s")
 	// CompilerABIReRead could not re-read serialized output after writing the ABI
-	CompilerABIReRead = "Parsing ABI: %s"
+	CompilerABIReRead = e(100012, "Parsing ABI: %s")
 	// CompilerSerializeDevDocs could not serialize the dev docs output from solc
-	CompilerSerializeDevDocs = "Serializing DevDoc: %s"
+	CompilerSerializeDevDocs = e(100013, "Serializing DevDoc: %s")
 	// ConfigNoRPC missing config for JSON/RPC
-	ConfigNoRPC = "No JSON/RPC URL set for ethereum node"
+	ConfigNoRPC = e(100014, "No JSON/RPC URL set for ethereum node")
 	// ConfigKafkaMissingOutputTopic response topic missing
-	ConfigKafkaMissingOutputTopic = "No output topic specified for bridge to send events to"
+	ConfigKafkaMissingOutputTopic = e(100015, "No output topic specified for bridge to send events to")
 	// ConfigKafkaMissingInputTopic request topic missing
-	ConfigKafkaMissingInputTopic = "No input topic specified for bridge to listen to"
+	ConfigKafkaMissingInputTopic = e(100016, "No input topic specified for bridge to listen to")
 	// ConfigKafkaMissingConsumerGroup consumer group missing
-	ConfigKafkaMissingConsumerGroup = "No consumer group specified"
+	ConfigKafkaMissingConsumerGroup = e(100017, "No consumer group specified")
 	// ConfigKafkaMissingBadSASL problem with SASL config
-	ConfigKafkaMissingBadSASL = "Username and Password must both be provided for SASL"
+	ConfigKafkaMissingBadSASL = e(100018, "Username and Password must both be provided for SASL")
 	// ConfigKafkaMissingBrokers missing/empty brokers
-	ConfigKafkaMissingBrokers = "No Kafka brokers configured"
+	ConfigKafkaMissingBrokers = e(100019, "No Kafka brokers configured")
 	// ConfigRESTGatewayRequiredReceiptStore need to enable params for REST Gatewya
-	ConfigRESTGatewayRequiredReceiptStore = "MongoDB URL, Database and Collection name must be specified to enable the receipt store"
+	ConfigRESTGatewayRequiredReceiptStore = e(100020, "MongoDB URL, Database and Collection name must be specified to enable the receipt store")
 	// ConfigRESTGatewayRequiredRPC and RPC stuff
-	ConfigRESTGatewayRequiredRPC = "RPC URL and Storage Path must be supplied to enable the Open API REST Gateway"
+	ConfigRESTGatewayRequiredRPC = e(100021, "RPC URL and Storage Path must be supplied to enable the Open API REST Gateway")
 	// ConfigWebhooksDirectRPC for webhooks direct
-	ConfigWebhooksDirectRPC = "No JSON/RPC URL set for ethereum node"
+	ConfigWebhooksDirectRPC = e(100022, "No JSON/RPC URL set for ethereum node")
 	// ConfigTLSCertOrKey incomplete TLS config
-	ConfigTLSCertOrKey = "Client private key and certificate must both be provided for mutual auth"
+	ConfigTLSCertOrKey = e(100023, "Client private key and certificate must both be provided for mutual auth")
 
 	// ConfigNoYAML missing configuration file on server start
-	ConfigNoYAML = "No YAML configuration filename specified"
+	ConfigNoYAML = e(100024, "No YAML configuration filename specified")
 	// ConfigYAMLParseFile failed to parse YAML during server startup
-	ConfigYAMLParseFile = "Unable to parse %s as YAML: %s"
+	ConfigYAMLParseFile = e(100025, "Unable to parse %s as YAML: %s")
 	// ConfigYAMLPostParseFile failed to process YAML as JSON after parsing
-	ConfigYAMLPostParseFile = "Failed to process YAML config from %s: %s"
+	ConfigYAMLPostParseFile = e(100026, "Failed to process YAML config from %s: %s")
 
 	// DeployTransactionMissingCode a DeployTransaction message, without code to deploy
-	DeployTransactionMissingCode = "Missing Compiled Code + ABI, or Solidity"
+	DeployTransactionMissingCode = e(100027, "Missing Compiled Code + ABI, or Solidity")
 
 	// EventStreamsDBLoad failed to init DB
-	EventStreamsDBLoad = "Failed to open DB at %s: %s"
+	EventStreamsDBLoad = e(100028, "Failed to open DB at %s: %s")
 	// EventStreamsNoID attempt to create an event stream/sub without an ID
-	EventStreamsNoID = "No ID"
+	EventStreamsNoID = e(100029, "No ID")
 	// EventStreamsInvalidActionType unknown action type
-	EventStreamsInvalidActionType = "Unknown action type '%s'"
+	EventStreamsInvalidActionType = e(100030, "Unknown action type '%s'")
 	// EventStreamsWebhookNoURL attempt to create a Webhook event stream without a URL
-	EventStreamsWebhookNoURL = "Must specify webhook.url for action type 'webhook'"
+	EventStreamsWebhookNoURL = e(100031, "Must specify webhook.url for action type 'webhook'")
 	// EventStreamsWebhookInvalidURL attempt to create a Webhook event stream with an invalid URL
-	EventStreamsWebhookInvalidURL = "Invalid URL in webhook action"
+	EventStreamsWebhookInvalidURL = e(100032, "Invalid URL in webhook action")
 	// EventStreamsWebhookResumeActive resume when already resumed
-	EventStreamsWebhookResumeActive = "Event processor is already active. Suspending:%t"
+	EventStreamsWebhookResumeActive = e(100033, "Event processor is already active. Suspending:%t")
 	// EventStreamsWebhookProhibitedAddress some IP ranges can be restricted
-	EventStreamsWebhookProhibitedAddress = "Cannot send Webhook POST to address: %s"
+	EventStreamsWebhookProhibitedAddress = e(100034, "Cannot send Webhook POST to address: %s")
 	// EventStreamsWebhookFailedHTTPStatus server at the other end of a webhook returned a non-OK response
-	EventStreamsWebhookFailedHTTPStatus = "%s: Failed with status=%d"
+	EventStreamsWebhookFailedHTTPStatus = e(100035, "%s: Failed with status=%d")
 	// EventStreamsSubscribeBadBlock the starting block for a subscription request is invalid
-	EventStreamsSubscribeBadBlock = "FromBlock cannot be parsed as a BigInt"
+	EventStreamsSubscribeBadBlock = e(100036, "FromBlock cannot be parsed as a BigInt")
 	// EventStreamsSubscribeStoreFailed problem saving a subscription to our DB
-	EventStreamsSubscribeStoreFailed = "Failed to store subscription: %s"
+	EventStreamsSubscribeStoreFailed = e(100037, "Failed to store subscription: %s")
 	// EventStreamsSubscribeNoEvent missing event
-	EventStreamsSubscribeNoEvent = "Solidity event name must be specified"
+	EventStreamsSubscribeNoEvent = e(100038, "Solidity event name must be specified")
 	// EventStreamsSubscriptionNotFound sub not found
-	EventStreamsSubscriptionNotFound = "Subscription with ID '%s' not found"
+	EventStreamsSubscriptionNotFound = e(100039, "Subscription with ID '%s' not found")
 	// EventStreamsCreateStreamStoreFailed problem saving a subscription to our DB
-	EventStreamsCreateStreamStoreFailed = "Failed to store stream: %s"
+	EventStreamsCreateStreamStoreFailed = e(100040, "Failed to store stream: %s")
 	// EventStreamsCreateStreamResourceErr problem creating a resource required by the eventstream
-	EventStreamsCreateStreamResourceErr = "Failed to create a resource for the stream: %s"
+	EventStreamsCreateStreamResourceErr = e(100041, "Failed to create a resource for the stream: %s")
 	// EventStreamsStreamNotFound stream not found
-	EventStreamsStreamNotFound = "Stream with ID '%s' not found"
+	EventStreamsStreamNotFound = e(100042, "Stream with ID '%s' not found")
 	// EventStreamsLogDecode problem decoding the logs for an event emitted on the chain
-	EventStreamsLogDecode = "%s: Failed to decode data: %s"
+	EventStreamsLogDecode = e(100043, "%s: Failed to decode data: %s")
 	// EventStreamsLogDecodeInsufficientTopics ran out of topics according to the indexed fields described on the ABI event
-	EventStreamsLogDecodeInsufficientTopics = "%s: Ran out of topics for indexed fields at field %d of %s"
+	EventStreamsLogDecodeInsufficientTopics = e(100044, "%s: Ran out of topics for indexed fields at field %d of %s")
 	// EventStreamsLogDecodeData RLP decoding of the data section of the logs failed
-	EventStreamsLogDecodeData = "%s: Failed to parse RLP data from event: %s"
+	EventStreamsLogDecodeData = e(100045, "%s: Failed to parse RLP data from event: %s")
 	// EventStreamsWebSocketNotConfigured WebSocket not configured
-	EventStreamsWebSocketNotConfigured = "WebSocket listener not configured"
+	EventStreamsWebSocketNotConfigured = e(100046, "WebSocket listener not configured")
 	// EventStreamsWebSocketInterruptedSend When we are interrupted waiting for a viable connection to send down
-	EventStreamsWebSocketInterruptedSend = "Interrupted waiting for WebSocket connection to send event"
+	EventStreamsWebSocketInterruptedSend = e(100047, "Interrupted waiting for WebSocket connection to send event")
 	// EventStreamsWebSocketInterruptedReceive When we are interrupted waiting for a viable connection to send down
-	EventStreamsWebSocketInterruptedReceive = "Interrupted waiting for WebSocket acknowledgment"
+	EventStreamsWebSocketInterruptedReceive = e(100048, "Interrupted waiting for WebSocket acknowledgment")
 	// EventStreamsWebSocketErrorFromClient Error message received from client
-	EventStreamsWebSocketErrorFromClient = "Error received from WebSocket client: %s"
+	EventStreamsWebSocketErrorFromClient = e(100049, "Error received from WebSocket client: %s")
 	// EventStreamsCannotUpdateType cannot change tyep
-	EventStreamsCannotUpdateType = "The type of an event stream cannot be changed"
+	EventStreamsCannotUpdateType = e(100050, "The type of an event stream cannot be changed")
 	// EventStreamsInvalidDistributionMode unknown distribution mode
-	EventStreamsInvalidDistributionMode = "Invalid distribution mode '%s'. Valid distribution modes are: 'workloadDistribution' and 'broadcast'."
+	EventStreamsInvalidDistributionMode = e(100051, "Invalid distribution mode '%s'. Valid distribution modes are: 'workloadDistribution' and 'broadcast'.")
 	// EventStreamsUpdateAlreadyInProgress update already in progress
-	EventStreamsUpdateAlreadyInProgress = "Update to event stream already in progress"
+	EventStreamsUpdateAlreadyInProgress = e(100052, "Update to event stream already in progress")
 
 	// KakfaProducerConfirmMsgUnknown we received a confirmation callback, but we aren't expecting it
-	KakfaProducerConfirmMsgUnknown = "Received confirmation for message not in in-flight map: %s"
+	KakfaProducerConfirmMsgUnknown = e(100053, "Received confirmation for message not in in-flight map: %s")
 
 	// KVStoreDBLoad failed to init DB
-	KVStoreDBLoad = "Failed to open DB at %s: %s"
+	KVStoreDBLoad = e(100054, "Failed to open DB at %s: %s")
 	// KVStoreMemFilteringUnsupported memory db is really just for testing. No filtering support
-	KVStoreMemFilteringUnsupported = "Memory receipts do not support filtering"
+	KVStoreMemFilteringUnsupported = e(100055, "Memory receipts do not support filtering")
 
 	// HDWalletSigningFailed problem returned from remote HDWallet API
-	HDWalletSigningFailed = "HDWallet signing failed"
+	HDWalletSigningFailed = e(100056, "HDWallet signing failed")
 	// HDWalletSigningBadData we got a response, but not with the correct fields
-	HDWalletSigningBadData = "Unexpected response from HDWallet"
+	HDWalletSigningBadData = e(100057, "Unexpected response from HDWallet")
 	// HDWalletSigningNoConfig we had a request for HD Wallet signing, but we don't have the required config
-	HDWalletSigningNoConfig = "No HD Wallet Configuration"
+	HDWalletSigningNoConfig = e(100058, "No HD Wallet Configuration")
 
 	// HelperStrToAddressRequiredField re-usable error for missing fields
-	HelperStrToAddressRequiredField = "'%s' must be supplied"
+	HelperStrToAddressRequiredField = e(100059, "'%s' must be supplied")
 	// HelperStrToAddressBadAddress re-usable error for bad address
-	HelperStrToAddressBadAddress = "Supplied value for '%s' is not a valid hex address"
+	HelperStrToAddressBadAddress = e(100060, "Supplied value for '%s' is not a valid hex address")
 	// HelperYAMLorJSONPayloadTooLarge input message too large
-	HelperYAMLorJSONPayloadTooLarge = "Message exceeds maximum allowable size"
+	HelperYAMLorJSONPayloadTooLarge = e(100061, "Message exceeds maximum allowable size")
 	// HelperYAMLorJSONPayloadReadFailed failed to read input
-	HelperYAMLorJSONPayloadReadFailed = "Unable to read input data: %s"
+	HelperYAMLorJSONPayloadReadFailed = e(100062, "Unable to read input data: %s")
 	// HelperYAMLorJSONPayloadParseFailed input message got error parsing
-	HelperYAMLorJSONPayloadParseFailed = "Unable to parse as YAML or JSON: %s"
+	HelperYAMLorJSONPayloadParseFailed = e(100063, "Unable to parse as YAML or JSON: %s")
 
 	// HTTPRequesterSerializeFailed common HTTP request utility for extensions, failed to serialize request
-	HTTPRequesterSerializeFailed = "Failed to serialize request payload: %s"
+	HTTPRequesterSerializeFailed = e(100064, "Failed to serialize request payload: %s")
 	// HTTPRequesterNonStatusError common HTTP request utility for extensions, got an error sending a request
-	HTTPRequesterNonStatusError = "Error querying %s"
+	HTTPRequesterNonStatusError = e(100065, "Error querying %s")
 	// HTTPRequesterStatusErrorNoData common HTTP request utility for extensions, got a status code, but couldn't deserialize payload
-	HTTPRequesterStatusErrorNoData = "Could not process %s [%d] response"
+	HTTPRequesterStatusErrorNoData = e(100066, "Could not process %s [%d] response")
 	// HTTPRequesterStatusErrorWithData common HTTP request utility for extensions, got a non-ok status code with JSON errorMessage
-	HTTPRequesterStatusErrorWithData = "%s returned [%d]: %s"
+	HTTPRequesterStatusErrorWithData = e(100067, "%s returned [%d]: %s")
 	// HTTPRequesterStatusError common HTTP request utility for extensions, got a non-ok status code
-	HTTPRequesterStatusError = "Error querying %s"
+	HTTPRequesterStatusError = e(100068, "Error querying %s")
 	// HTTPRequesterResponseMissingField common HTTP request utility for extensions, missing expected field in response
-	HTTPRequesterResponseMissingField = "'%s' missing in %s response"
+	HTTPRequesterResponseMissingField = e(100069, "'%s' missing in %s response")
 	// HTTPRequesterResponseNonStringField common HTTP request utility for extensions, expected string for field in response
-	HTTPRequesterResponseNonStringField = "'%s' not a string in %s response"
+	HTTPRequesterResponseNonStringField = e(100070, "'%s' not a string in %s response")
 	// HTTPRequesterResponseNullField common HTTP request utility for extensions, expected non-empty response field
-	HTTPRequesterResponseNullField = "'%s' empty (or null) in %s response"
+	HTTPRequesterResponseNullField = e(100071, "'%s' empty (or null) in %s response")
 
 	// ReceiptStoreDisabled not configured
-	ReceiptStoreDisabled = "Receipt store not enabled"
+	ReceiptStoreDisabled = e(100072, "Receipt store not enabled")
 	// ReceiptStoreDBLoad failed to init DB
-	ReceiptStoreDBLoad = "Failed to open DB at %s: %s"
+	ReceiptStoreDBLoad = e(100073, "Failed to open DB at %s: %s")
 	// ReceiptStoreMongoDBConnect couldn't connect to MongoDB
-	ReceiptStoreMongoDBConnect = "Unable to connect to MongoDB: %s"
+	ReceiptStoreMongoDBConnect = e(100074, "Unable to connect to MongoDB: %s")
 	// ReceiptStoreMongoDBIndex couldn't create MongoDB index
-	ReceiptStoreMongoDBIndex = "Unable to create index: %s"
+	ReceiptStoreMongoDBIndex = e(100075, "Unable to create index: %s")
 	// ReceiptStoreLevelDBConnect couldn't open file for the level DB
-	ReceiptStoreLevelDBConnect = "Unable to open LevelDB: %s"
+	ReceiptStoreLevelDBConnect = e(100076, "Unable to open LevelDB: %s")
 	// ReceiptStoreSerializeResponse problem sending a receipt stored back over the REST API
-	ReceiptStoreSerializeResponse = "Error serializing response"
+	ReceiptStoreSerializeResponse = e(100077, "Error serializing response")
 	// ReceiptStoreInvalidRequestID bad ID query
-	ReceiptStoreInvalidRequestID = "Invalid 'id' query parameter"
+	ReceiptStoreInvalidRequestID = e(100078, "Invalid 'id' query parameter")
 	// ReceiptStoreInvalidRequestMaxLimit bad limit over max
-	ReceiptStoreInvalidRequestMaxLimit = "Maximum limit is %d"
+	ReceiptStoreInvalidRequestMaxLimit = e(100079, "Maximum limit is %d")
 	// ReceiptStoreInvalidRequestBadLimit bad limit
-	ReceiptStoreInvalidRequestBadLimit = "Invalid 'limit' query parameter"
+	ReceiptStoreInvalidRequestBadLimit = e(100080, "Invalid 'limit' query parameter")
 	// ReceiptStoreInvalidRequestBadSkip bad skip
-	ReceiptStoreInvalidRequestBadSkip = "Invalid 'skip' query parameter"
+	ReceiptStoreInvalidRequestBadSkip = e(100081, "Invalid 'skip' query parameter")
 	// ReceiptStoreInvalidRequestBadSince bad since
-	ReceiptStoreInvalidRequestBadSince = "since cannot be parsed as RFC3339 or millisecond timestamp"
+	ReceiptStoreInvalidRequestBadSince = e(100082, "since cannot be parsed as RFC3339 or millisecond timestamp")
 	// ReceiptStoreFailedQuery wrapper over detailed error
-	ReceiptStoreFailedQuery = "Error querying replies: %s"
+	ReceiptStoreFailedQuery = e(100083, "Error querying replies: %s")
 	// ReceiptStoreFailedQuerySingle wrapper over detailed error
-	ReceiptStoreFailedQuerySingle = "Error querying reply: %s"
+	ReceiptStoreFailedQuerySingle = e(100084, "Error querying reply: %s")
 	// ReceiptStoreFailedNotFound receipt isn't in the store
-	ReceiptStoreFailedNotFound = "Receipt not available"
+	ReceiptStoreFailedNotFound = e(100085, "Receipt not available")
 
 	// RemoteRegistryCacheInit initialzation issue for remote contract registry
-	RemoteRegistryCacheInit = "Failed to initialize cache for remote registry: %s"
+	RemoteRegistryCacheInit = e(100086, "Failed to initialize cache for remote registry: %s")
 	// RemoteRegistryNotConfigured cannot register as a remote registry is not configured
-	RemoteRegistryNotConfigured = "No remote registry is configured"
+	RemoteRegistryNotConfigured = e(100087, "No remote registry is configured")
 	// RemoteRegistryRegistrationFailed error during registration with remote contract registry
-	RemoteRegistryRegistrationFailed = "Failed to register instance in remote registry: %s"
+	RemoteRegistryRegistrationFailed = e(100088, "Failed to register instance in remote registry: %s")
 	// RemoteRegistryLookupGatewayNotFound did not find the requested ID in the remote registry for a gateway/factory
-	RemoteRegistryLookupGatewayNotFound = "Gateway not found"
+	RemoteRegistryLookupGatewayNotFound = e(100089, "Gateway not found")
 	// RemoteRegistryLookupInstanceNotFound did not find the requested ID in the remote registry for a contract instance
-	RemoteRegistryLookupInstanceNotFound = "Instance not found"
+	RemoteRegistryLookupInstanceNotFound = e(100090, "Instance not found")
 	// RemoteRegistryLookupGenericProcessingFailed we don't return the full original error over the REST API after logging
-	RemoteRegistryLookupGenericProcessingFailed = "Error processing contract registry response"
+	RemoteRegistryLookupGenericProcessingFailed = e(100091, "Error processing contract registry response")
 
 	// RESTGatewayGatewayNotFound the gateway REST API interface (the 'factory' / ABI generic interface) was not found
-	RESTGatewayGatewayNotFound = "Gateway not found"
+	RESTGatewayGatewayNotFound = e(100092, "Gateway not found")
 	// RESTGatewayInstanceNotFound the instance REST API interface (an individual registered address) was not found
-	RESTGatewayInstanceNotFound = "Instance not found"
+	RESTGatewayInstanceNotFound = e(100093, "Instance not found")
 	// RESTGatewayEventNotDeclared attempt to subscribe to an event on an instance that does not exist
-	RESTGatewayEventNotDeclared = "Event '%s' is not declared in the ABI"
+	RESTGatewayEventNotDeclared = e(100094, "Event '%s' is not declared in the ABI")
 	// RESTGatewayMethodNotDeclared attempt to invoke a method name that does not exist in the ABI, or register globally for an event that doesn't exist
-	RESTGatewayMethodNotDeclared = "Method or Event '%s' is not declared in the ABI of contract '%s'"
+	RESTGatewayMethodNotDeclared = e(100095, "Method or Event '%s' is not declared in the ABI of contract '%s'")
 	// RESTGatewayInvalidToAddress failed to parse a 'to' address supplied on a path
-	RESTGatewayInvalidToAddress = "To Address must be a 40 character hex string (0x prefix is optional)"
+	RESTGatewayInvalidToAddress = e(100096, "To Address must be a 40 character hex string (0x prefix is optional)")
 	// RESTGatewayInvalidFromAddress failed to parse a 'from' address supplied on a path
-	RESTGatewayInvalidFromAddress = "From Address must be a 40 character hex string (0x prefix is optional)"
+	RESTGatewayInvalidFromAddress = e(100097, "From Address must be a 40 character hex string (0x prefix is optional)")
 	// RESTGatewayMissingParameter did not supply a parameter required by the method
-	RESTGatewayMissingParameter = "Parameter '%s' of method '%s' was not specified in body or query parameters"
+	RESTGatewayMissingParameter = e(100098, "Parameter '%s' of method '%s' was not specified in body or query parameters")
 	// RESTGatewayMissingFromAddress did not supply a signing address for the transaction
-	RESTGatewayMissingFromAddress = "Please specify a valid address in the '%[1]s-from' query string parameter or x-%[2]s-from HTTP header"
+	RESTGatewayMissingFromAddress = e(100099, "Please specify a valid address in the '%[1]s-from' query string parameter or x-%[2]s-from HTTP header")
 	// RESTGatewaySubscribeMissingStreamParameter missed the ID of the stream when registering
-	RESTGatewaySubscribeMissingStreamParameter = "Must supply a 'stream' parameter in the body or query"
+	RESTGatewaySubscribeMissingStreamParameter = e(100100, "Must supply a 'stream' parameter in the body or query")
 	// RESTGatewayMixedPrivateForAndGroupID confused privacy group info, using simple/Tessera style as well as pre-defined/Orion style
-	RESTGatewayMixedPrivateForAndGroupID = "%[1]s-privatefor and %[1]s-privacygroupid are mutually exclusive"
+	RESTGatewayMixedPrivateForAndGroupID = e(100101, "%[1]s-privatefor and %[1]s-privacygroupid are mutually exclusive")
 	// RESTGatewayEventManagerInitFailed constructor failure for event manager
-	RESTGatewayEventManagerInitFailed = "Event-stream subscription manager: %s"
+	RESTGatewayEventManagerInitFailed = e(100102, "Event-stream subscription manager: %s")
 	// RESTGatewayEventStreamInvalid attempt to create an event stream with invalid parameters
-	RESTGatewayEventStreamInvalid = "Invalid event stream specification: %s"
+	RESTGatewayEventStreamInvalid = e(100103, "Invalid event stream specification: %s")
 	// RESTGatewayPostDeployMissingAddress after deployment the receipt did not contain a contract address
-	RESTGatewayPostDeployMissingAddress = "%s: Missing contract address in receipt"
+	RESTGatewayPostDeployMissingAddress = e(100104, "%s: Missing contract address in receipt")
 	// RESTGatewayRegistrationSuppliedInvalidAddress invalid address when registering an existing instance of a contract
-	RESTGatewayRegistrationSuppliedInvalidAddress = "Invalid address in path - must be a 40 character hex string with optional 0x prefix"
+	RESTGatewayRegistrationSuppliedInvalidAddress = e(100105, "Invalid address in path - must be a 40 character hex string with optional 0x prefix")
 	// RESTGatewaySyncMsgTypeMismatch sync-invoke code paths in REST API Gateway should be maintained such that this cannot happen
-	RESTGatewaySyncMsgTypeMismatch = "Unexpected condition (message types do not match when processing)"
+	RESTGatewaySyncMsgTypeMismatch = e(100106, "Unexpected condition (message types do not match when processing)")
 	// RESTGatewaySyncWrapErrorWithTXDetail wraps a low level error with transaction hash context on sync APIs before returning
-	RESTGatewaySyncWrapErrorWithTXDetail = "TX %s: %s"
+	RESTGatewaySyncWrapErrorWithTXDetail = e(100107, "TX %s: %s")
 	// RESTGatewayMethodTypeInvalid unsupported method type
-	RESTGatewayMethodTypeInvalid = "Unsupported method type: %s"
+	RESTGatewayMethodTypeInvalid = e(100108, "Unsupported method type: %s")
 	// RESTGatewayMethodABIInvalid error processing method from ABI
-	RESTGatewayMethodABIInvalid = "Invalid method '%s' in ABI: %s"
+	RESTGatewayMethodABIInvalid = e(100109, "Invalid method '%s' in ABI: %s")
 	// RESTGatewayEventABIInvalid error processing method from ABI
-	RESTGatewayEventABIInvalid = "Invalid event '%s' in ABI: %s"
+	RESTGatewayEventABIInvalid = e(100110, "Invalid event '%s' in ABI: %s")
 
 	// RESTGatewayCompileContractInvalidFormData invalid form data when requesting a compilation to generate an ABI/bytecode
-	RESTGatewayCompileContractInvalidFormData = "Could not parse supplied multi-part form data: %s"
+	RESTGatewayCompileContractInvalidFormData = e(100111, "Could not parse supplied multi-part form data: %s")
 	// RESTGatewayCompileContractCompileFailed failed to perform compile
-	RESTGatewayCompileContractCompileFailed = "Failed to compile solidity: %s"
+	RESTGatewayCompileContractCompileFailed = e(100112, "Failed to compile solidity: %s")
 	// RESTGatewayCompileContractPostCompileFailed failed to process output of compilation
-	RESTGatewayCompileContractPostCompileFailed = "Failed to process solidity: %s"
+	RESTGatewayCompileContractPostCompileFailed = e(100113, "Failed to process solidity: %s")
 	// RESTGatewayCompileContractExtractedReadFailed failed to read extracted contents of uploaded data
-	RESTGatewayCompileContractExtractedReadFailed = "Failed to read extracted multi-part form data"
+	RESTGatewayCompileContractExtractedReadFailed = e(100114, "Failed to read extracted multi-part form data")
 	// RESTGatewayCompileContractNoSOL failed to find any solidity files in uploaded data
-	RESTGatewayCompileContractNoSOL = "No .sol files found in root. Please set a 'source' query param or form field to the relative path of your solidity"
+	RESTGatewayCompileContractNoSOL = e(100115, "No .sol files found in root. Please set a 'source' query param or form field to the relative path of your solidity")
 	// RESTGatewayCompileContractSolcVerFail failed while checking version of solidity compiler 'solc'
-	RESTGatewayCompileContractSolcVerFail = "Failed checking solc version: %s"
+	RESTGatewayCompileContractSolcVerFail = e(100116, "Failed checking solc version: %s")
 	// RESTGatewayCompileContractCompileFailDetails output from compiler failure
-	RESTGatewayCompileContractCompileFailDetails = "Failed to compile [%s]: %s"
+	RESTGatewayCompileContractCompileFailDetails = e(100117, "Failed to compile [%s]: %s")
 	// RESTGatewayCompileContractSolcOutputProcessFail failed to process output of compilation
-	RESTGatewayCompileContractSolcOutputProcessFail = "Failed to parse solc output: %s"
+	RESTGatewayCompileContractSolcOutputProcessFail = e(100118, "Failed to parse solc output: %s")
 	// RESTGatewayCompileContractSlashes unsafe slash characters in filenames
-	RESTGatewayCompileContractSlashes = "Filenames cannot contain slashes. Use a zip file to upload a directory structure"
+	RESTGatewayCompileContractSlashes = e(100119, "Filenames cannot contain slashes. Use a zip file to upload a directory structure")
 	// RESTGatewayCompileContractUnzipRead error opening zip/tgz to read (no extra information to remote caller)
-	RESTGatewayCompileContractUnzipRead = "Failed to read archive"
+	RESTGatewayCompileContractUnzipRead = e(100120, "Failed to read archive")
 	// RESTGatewayCompileContractUnzipWrite error writing extracted zip (no extra information to remote caller)
-	RESTGatewayCompileContractUnzipWrite = "Failed to process archive"
+	RESTGatewayCompileContractUnzipWrite = e(100121, "Failed to process archive")
 	// RESTGatewayCompileContractUnzipCopy error writing extracted zip (no extra information to remote caller)
-	RESTGatewayCompileContractUnzipCopy = "Failed to process archive"
+	RESTGatewayCompileContractUnzipCopy = e(100122, "Failed to process archive")
 	// RESTGatewayCompileContractUnzip failure thrown from decompression library during extract
-	RESTGatewayCompileContractUnzip = "Error unarchiving supplied zip file: %s"
+	RESTGatewayCompileContractUnzip = e(100123, "Error unarchiving supplied zip file: %s")
 
 	// RESTGatewayLocalStoreContractSave local filesystem storage failure for contract instance (non-registry code flow)
-	RESTGatewayLocalStoreContractSave = "Failed to write ABI JSON: %s"
+	RESTGatewayLocalStoreContractSave = e(100124, "Failed to write ABI JSON: %s")
 	// RESTGatewayLocalStoreContractLoad local filesystem load failure for contract instance (non-registry code flow)
-	RESTGatewayLocalStoreContractLoad = "Failed to find installed contract address for '%s'"
+	RESTGatewayLocalStoreContractLoad = e(100125, "Failed to find installed contract address for '%s'")
 	// RESTGatewayLocalStoreContractNotFound local filesystem not found (non-registry code flow)
-	RESTGatewayLocalStoreContractNotFound = "No contract instance registered with address %s"
+	RESTGatewayLocalStoreContractNotFound = e(100126, "No contract instance registered with address %s")
 	// RESTGatewayLocalStoreABINotFound lookup of ABI failed not found (non-registry code flow)
-	RESTGatewayLocalStoreABINotFound = "No ABI found with ID %s"
+	RESTGatewayLocalStoreABINotFound = e(100127, "No ABI found with ID %s")
 	// RESTGatewayLocalStoreABILoad local filesystem load failure for ABI details (non-registry code flow)
-	RESTGatewayLocalStoreABILoad = "Failed to load ABI with ID %s: %s"
+	RESTGatewayLocalStoreABILoad = e(100128, "Failed to load ABI with ID %s: %s")
 	// RESTGatewayLocalStoreABIParse local filesystem parse failure for ABI details (non-registry code flow)
-	RESTGatewayLocalStoreABIParse = "Failed to parse ABI with ID %s: %s"
+	RESTGatewayLocalStoreABIParse = e(100129, "Failed to parse ABI with ID %s: %s")
 	// RESTGatewayLocalStoreMissingABI did not supply ABI JSON when attempting to install ABI (non-registry code flow)
-	RESTGatewayLocalStoreMissingABI = "Must supply ABI to install an existing ABI into the REST Gateway"
+	RESTGatewayLocalStoreMissingABI = e(100130, "Must supply ABI to install an existing ABI into the REST Gateway")
 	// RESTGatewayInvalidABI invalid serialized ABI in msg
-	RESTGatewayInvalidABI = "Invalid ABI: %s"
+	RESTGatewayInvalidABI = e(100131, "Invalid ABI: %s")
 	// RESTGatewayLocalStoreContractSavePostDeploy local filesystem storage failure for contract instance post deploy (non-registry code flow)
-	RESTGatewayLocalStoreContractSavePostDeploy = "%s: Failed to write deployment details: %s"
+	RESTGatewayLocalStoreContractSavePostDeploy = e(100132, "%s: Failed to write deployment details: %s")
 	// RESTGatewayFriendlyNameClash duplicate friendly name when reigstering
-	RESTGatewayFriendlyNameClash = "Contract address %s is already registered for name '%s'"
+	RESTGatewayFriendlyNameClash = e(100133, "Contract address %s is already registered for name '%s'")
 	// RESTGatewayResourceErr problem creating a resource required by the gateway
-	RESTGatewayResourceErr = "Failed to create a resource for the REST Gateway: %s"
+	RESTGatewayResourceErr = e(100134, "Failed to create a resource for the REST Gateway: %s")
 
 	// RPCCallReturnedError specified RPC call returned error
-	RPCCallReturnedError = "%s returned: %s"
+	RPCCallReturnedError = e(100135, "%s returned: %s")
 	// RPCConnectFailed error connecting to back-end server over JSON/RPC
-	RPCConnectFailed = "JSON/RPC connection to %s failed: %s"
+	RPCConnectFailed = e(100136, "JSON/RPC connection to %s failed: %s")
 
 	// SecurityModulePluginLoad failed to load .so
-	SecurityModulePluginLoad = "Failed to load plugin: %s"
+	SecurityModulePluginLoad = e(100137, "Failed to load plugin: %s")
 	// SecurityModulePluginSymbol missing symbol in plugin
-	SecurityModulePluginSymbol = "Failed to load 'SecurityModule' symbol from '%s': %s"
+	SecurityModulePluginSymbol = e(100138, "Failed to load 'SecurityModule' symbol from '%s': %s")
 	// SecurityModuleNoAuthContext missing auth context in context object at point security module is invoked
-	SecurityModuleNoAuthContext = "No auth context"
+	SecurityModuleNoAuthContext = e(100140, "No auth context")
 
 	// TransactionQueryFailed transaction lookup failed
-	TransactionQueryFailed = "Failed to query transaction: %s"
+	TransactionQueryFailed = e(100141, "Failed to query transaction: %s")
 	// TransactionQueryMethodMismatch transaction input did not match the method queried
-	TransactionQueryMethodMismatch = "Method signature did not match: %s != %s"
+	TransactionQueryMethodMismatch = e(100142, "Method signature did not match: %s != %s")
 
 	// TransactionSendConstructorPackArgs RLP encoding failure for a constructor
-	TransactionSendConstructorPackArgs = "Packing arguments for constructor: %s"
+	TransactionSendConstructorPackArgs = e(100143, "Packing arguments for constructor: %s")
 	// TransactionSendMethodPackArgs RLP encoding failure for a method
-	TransactionSendMethodPackArgs = "Packing arguments for method '%s': %s"
+	TransactionSendMethodPackArgs = e(100144, "Packing arguments for method '%s': %s")
 	// TransactionSendInputTypeUnknown there is a type in the ABI inputs that we don't understand
-	TransactionSendInputTypeUnknown = "ABI input %d: Unable to map %s to etherueum type: %s"
+	TransactionSendInputTypeUnknown = e(100145, "ABI input %d: Unable to map %s to etherueum type: %s")
 	// TransactionSendOutputTypeUnknown there is a type in the ABI outputs that we don't understand
-	TransactionSendOutputTypeUnknown = "ABI output %d: Unable to map %s to etherueum type: %s"
+	TransactionSendOutputTypeUnknown = e(100146, "ABI output %d: Unable to map %s to etherueum type: %s")
 	// TransactionSendGasEstimateFailed gas estimation failed prior to sending TX
-	TransactionSendGasEstimateFailed = "Failed to calculate gas for transaction: %s"
+	TransactionSendGasEstimateFailed = e(100147, "Failed to calculate gas for transaction: %s")
 	// TransactionSendCallFailedNoRevert failed to perform an eth_call with a JSON/RPC error (not a revert)
-	TransactionSendCallFailedNoRevert = "Call failed: %s"
+	TransactionSendCallFailedNoRevert = e(100148, "Call failed: %s")
 	// TransactionSendCallFailedRevertMessage directly passes the revert message from the EVM
-	TransactionSendCallFailedRevertMessage = "%s"
+	TransactionSendCallFailedRevertMessage = e(100149, "%s")
 	// TransactionSendCallFailedRevertNoMessage when we couldn't process the EVM revert message
-	TransactionSendCallFailedRevertNoMessage = "EVM reverted. Failed to decode error message"
+	TransactionSendCallFailedRevertNoMessage = e(100150, "EVM reverted. Failed to decode error message")
 	// TransactionSendMissingPrivateFromOrion there is no default privateFrom in Orion, so the user must always supply it
-	TransactionSendMissingPrivateFromOrion = "private-from is required when submitting private transactions via Orion"
+	TransactionSendMissingPrivateFromOrion = e(100151, "private-from is required when submitting private transactions via Orion")
 	// TransactionSendPrivateTXWithExternalSigner we don't allow private transactions to be combined with a HD Wallet or other external signer currently
-	TransactionSendPrivateTXWithExternalSigner = "Signing with %s is not currently supported with private transactions"
+	TransactionSendPrivateTXWithExternalSigner = e(100152, "Signing with %s is not currently supported with private transactions")
 	// TransactionSendPrivateForAndPrivacyGroup mixed both params
-	TransactionSendPrivateForAndPrivacyGroup = "privacyGroupId and privateFor are mutually exclusive"
+	TransactionSendPrivateForAndPrivacyGroup = e(100153, "privacyGroupId and privateFor are mutually exclusive")
 	// TransactionSendNonceFailWithPrivacyGroup when we successfully lookup the privacy group, but cannot get the nonce
-	TransactionSendNonceFailWithPrivacyGroup = "priv_getTransactionCount for privacy group '%s' returned: %s"
+	TransactionSendNonceFailWithPrivacyGroup = e(100154, "priv_getTransactionCount for privacy group '%s' returned: %s")
 	// TransactionSendMissingMethod a request to send a transaction was received (webhook/Kafka) that was missing method details (unexpected when using REST APIs that validate this)
-	TransactionSendMissingMethod = "Method missing - must provide inline 'param' type/value pairs with a 'methodName', or an ABI in 'method'"
+	TransactionSendMissingMethod = e(100155, "Method missing - must provide inline 'param' type/value pairs with a 'methodName', or an ABI in 'method'")
 	// TransactionSendBadNonce a user-supplied nonce string in the JSON input cannot be processed
-	TransactionSendBadNonce = "Converting supplied 'nonce' to integer: %s"
+	TransactionSendBadNonce = e(100156, "Converting supplied 'nonce' to integer: %s")
 	// TransactionSendBadValue a user-supplied value (eth amount to transfer) string in the JSON input cannot be processed
-	TransactionSendBadValue = "Converting supplied 'value' to big integer: %s"
+	TransactionSendBadValue = e(100157, "Converting supplied 'value' to big integer: %s")
 	// TransactionSendBadGas a user-supplied gas (maximum gas to spend on the TX) string in the JSON input cannot be processed
-	TransactionSendBadGas = "Converting supplied 'gas' to integer: %s"
+	TransactionSendBadGas = e(100158, "Converting supplied 'gas' to integer: %s")
 	// TransactionSendBadGasPrice a user-supplied gasPrice (eth to pay for each unit of gas spent) string in the JSON input cannot be processed
-	TransactionSendBadGasPrice = "Converting supplied 'gasPrice' to big integer"
+	TransactionSendBadGasPrice = e(100159, "Converting supplied 'gasPrice' to big integer")
 	// TransactionSendInputTypeBadNumber the input JSON value supplied for a method parameter cannot be converted to a number
-	TransactionSendInputTypeBadNumber = "Method '%s' param %s: Could not be converted to a number"
+	TransactionSendInputTypeBadNumber = e(100160, "Method '%s' param %s: Could not be converted to a number")
 	// TransactionSendInputTypeBadJSONTypeForNumber the input JSON value supplied for a method parameter was not a number or a string, and needs to be converted to a number
-	TransactionSendInputTypeBadJSONTypeForNumber = "Method '%s' param %s is a %s: Must supply a number or a string (supplied=%s)"
+	TransactionSendInputTypeBadJSONTypeForNumber = e(100161, "Method '%s' param %s is a %s: Must supply a number or a string (supplied=%s)")
 	// TransactionSendInputTypeBadJSONTypeForArray the input JSON value supplied for a method parameter was not compatible with coercion to an array
-	TransactionSendInputTypeBadJSONTypeForArray = "Method '%s' param %s is a %s: Must supply an array (supplied=%s)"
+	TransactionSendInputTypeBadJSONTypeForArray = e(100162, "Method '%s' param %s is a %s: Must supply an array (supplied=%s)")
 	// TransactionSendInputTypeBadNull the input JSON value supplied was null
-	TransactionSendInputTypeBadNull = "Method '%s' param %s: Cannot supply a null value"
+	TransactionSendInputTypeBadNull = e(100163, "Method '%s' param %s: Cannot supply a null value")
 	// TransactionSendInputTypeBadJSONTypeForBoolean the input JSON value supplied for a method parameter was not compatible with coercion to a boolean
-	TransactionSendInputTypeBadJSONTypeForBoolean = "Method '%s' param %s is a %s: Must supply a boolean or a string (supplied=%s)"
+	TransactionSendInputTypeBadJSONTypeForBoolean = e(100164, "Method '%s' param %s is a %s: Must supply a boolean or a string (supplied=%s)")
 	// TransactionSendInputTypeBadJSONTypeForString the input JSON value supplied for a method parameter was not compatible with coercion to a boolean
-	TransactionSendInputTypeBadJSONTypeForString = "Method '%s' param %s: Must supply a string (supplied=%s)"
+	TransactionSendInputTypeBadJSONTypeForString = e(100165, "Method '%s' param %s: Must supply a string (supplied=%s)")
 	// TransactionSendInputTypeAddress the input JSON value supplied for a method parameter couldn't be parsed as an eth address
-	TransactionSendInputTypeAddress = "Method '%s' param %s: Could not be converted to a hex address (supplied=%s)"
+	TransactionSendInputTypeAddress = e(100166, "Method '%s' param %s: Could not be converted to a hex address (supplied=%s)")
 	// TransactionSendInputTypeBadJSONTypeForAddress the input JSON value supplied for a method parameter was not compatible with coercion to an eth address
-	TransactionSendInputTypeBadJSONTypeForAddress = "Method '%s' param %s is a %s: Must supply a hex address string (supplied=%s)"
+	TransactionSendInputTypeBadJSONTypeForAddress = e(100167, "Method '%s' param %s is a %s: Must supply a hex address string (supplied=%s)")
 	// TransactionSendInputTypeBadJSONTypeInNumericArray one of the entries inside of a numeric array, is not valid as a number
-	TransactionSendInputTypeBadJSONTypeInNumericArray = "Method '%s' param %s is a %s: Invalid entry in number array at index %d (%s)"
+	TransactionSendInputTypeBadJSONTypeInNumericArray = e(100168, "Method '%s' param %s is a %s: Invalid entry in number array at index %d (%s)")
 	// TransactionSendInputTypeBadByteOutsideRange one of the entries inside of a byte array, is a number outside the range for bytes
-	TransactionSendInputTypeBadByteOutsideRange = "Method '%s' param %s is a %s: Invalid number - outside of range for byte"
+	TransactionSendInputTypeBadByteOutsideRange = e(100169, "Method '%s' param %s is a %s: Invalid number - outside of range for byte")
 	// TransactionSendInputTypeBadJSONTypeForBytes one of the entries inside of a byte array, is a number outside the range for bytes
-	TransactionSendInputTypeBadJSONTypeForBytes = "Method '%s' param %s is a %s: Must supply a hex string, or number array"
+	TransactionSendInputTypeBadJSONTypeForBytes = e(100170, "Method '%s' param %s is a %s: Must supply a hex string, or number array")
 	// TransactionSendInputTypeBadJSONTypeForTuple if we are provided a non object input on the JSON for a struct (tuple)
-	TransactionSendInputTypeBadJSONTypeForTuple = "Method '%s' param %s is a %s: Must supply an object (supplied=%s)"
+	TransactionSendInputTypeBadJSONTypeForTuple = e(100171, "Method '%s' param %s is a %s: Must supply an object (supplied=%s)")
 	// TransactionSendInputTypeNotSupported did not know how to handle this type - enhancement required
-	TransactionSendInputTypeNotSupported = "Type '%s' is not yet supported"
+	TransactionSendInputTypeNotSupported = e(100172, "Type '%s' is not yet supported")
 	// TransactionSendInputCountMismatch wrong number of args supplied according to the ABI
-	TransactionSendInputCountMismatch = "Method '%s': Requires %d args (supplied=%d)"
+	TransactionSendInputCountMismatch = e(100173, "Method '%s': Requires %d args (supplied=%d)")
 	// TransactionSendInputStructureWrong the JSON structure supplied to describe the arguments is incorrect according to our schema
-	TransactionSendInputStructureWrong = "Param %d: supplied as an object must have 'type' and 'value' fields"
+	TransactionSendInputStructureWrong = e(100174, "Param %d: supplied as an object must have 'type' and 'value' fields")
 	// TransactionSendInputInLineTypeArrayNotString when sending us an ABI definition for the inputs directly
-	TransactionSendInputInLineTypeArrayNotString = "Param %d: supplied as an object must be string"
+	TransactionSendInputInLineTypeArrayNotString = e(100175, "Param %d: supplied as an object must be string")
 	// TransactionSendInputInLineTypeUnknown when sending us an ABI definition for the inputs directly, the type string isn't known as an ethereum type
-	TransactionSendInputInLineTypeUnknown = "Param %d: Unable to map %s to etherueum type: %s"
+	TransactionSendInputInLineTypeUnknown = e(100176, "Param %d: Unable to map %s to etherueum type: %s")
 	// TransactionSendMsgTypeUnknown we got a JSON message into the core processor (from Kafka, Webhooks etc.) that we don't understand
-	TransactionSendMsgTypeUnknown = "Unknown message type '%s'"
+	TransactionSendMsgTypeUnknown = e(100177, "Unknown message type '%s'")
 	// TransactionSendInputTooManyParams more parameters provided than specified on ABI
-	TransactionSendInputTooManyParams = "Supplied %d parameters for ABI that supports %d"
+	TransactionSendInputTooManyParams = e(100178, "Supplied %d parameters for ABI that supports %d")
 	// TransactionSendInputNotAssignable if we end up in a situation where the generated type cannot be assigned
-	TransactionSendInputNotAssignable = "Method %s param %s: supplied value '%+v' could not be assigned to '%s' field (%s)"
+	TransactionSendInputNotAssignable = e(100180, "Method %s param %s: supplied value '%+v' could not be assigned to '%s' field (%s)")
 
 	// TransactionSendReceiptCheckError we continually had bad RCs back from the node while trying to check for the receipt up to the timeout
-	TransactionSendReceiptCheckError = "Error obtaining transaction receipt (%d retries): %s"
+	TransactionSendReceiptCheckError = e(100181, "Error obtaining transaction receipt (%d retries): %s")
 	// TransactionSendReceiptCheckTimeout we didn't have a problem asking the node for a receipt, but the transaction wasn't mined at the end of the timeout
-	TransactionSendReceiptCheckTimeout = "Timed out waiting for transaction receipt"
+	TransactionSendReceiptCheckTimeout = e(100182, "Timed out waiting for transaction receipt")
 
 	// TransactionCallInvalidBlockNumber on "eth_call" the optional parameter for the target blocknumber failed to parse to a big integer
-	TransactionCallInvalidBlockNumber = "Invalid blocknumber. Failed to parse into big integer"
+	TransactionCallInvalidBlockNumber = e(100183, "Invalid blocknumber. Failed to parse into big integer")
 
 	// UnpackOutputsFailed RLP decoding of outputs, logs, or events failed
-	UnpackOutputsFailed = "Failed to unpack values: %s"
+	UnpackOutputsFailed = e(100184, "Failed to unpack values: %s")
 	// UnpackOutputsMismatch RLP decoding of output gave an unexpected type according to the ABI
-	UnpackOutputsMismatch = "Expected %d type in JSON/RPC response. Received %d: %+v"
+	UnpackOutputsMismatch = e(100185, "Expected %d type in JSON/RPC response. Received %d: %+v")
 	// UnpackOutputsMismatchCount wrong number of arguments
-	UnpackOutputsMismatchCount = "Expected %d in JSON/RPC response. Received %d: %+v"
+	UnpackOutputsMismatchCount = e(100186, "Expected %d in JSON/RPC response. Received %d: %+v")
 	// UnpackOutputsMismatchNil RLP decoding of output gave a non-nil type, and we expected nil
-	UnpackOutputsMismatchNil = "Expected nil in JSON/RPC response. Received: %+v"
+	UnpackOutputsMismatchNil = e(100187, "Expected nil in JSON/RPC response. Received: %+v")
 	// UnpackOutputsMismatchType expected to find a number according to supplied ABI, but got something else
-	UnpackOutputsMismatchType = "Expected %s type in JSON/RPC response for %s (%s). Received %s"
+	UnpackOutputsMismatchType = e(100188, "Expected %s type in JSON/RPC response for %s (%s). Received %s")
 	// UnpackOutputsUnknownType did not know how to handle this type - enhancement required
-	UnpackOutputsUnknownType = "Unable to process type for %s (%s). Received %s"
+	UnpackOutputsUnknownType = e(100189, "Unable to process type for %s (%s). Received %s")
 	// UnpackOutputsMismatchTupleType we got a type back from the unpacking that doesn't match the ABI
-	UnpackOutputsMismatchTupleType = "Unable to process type for %s (%s). Expected %s. Received %+v"
+	UnpackOutputsMismatchTupleType = e(100190, "Unable to process type for %s (%s). Expected %s. Received %+v")
 	// UnpackOutputsMismatchTupleFieldCount we had a mismatch in the number of fields described on the ABI and the number on the go structure
-	UnpackOutputsMismatchTupleFieldCount = "Unable to process type for %s (%s). Expected %d fields on the structure. Received %d"
+	UnpackOutputsMismatchTupleFieldCount = e(100191, "Unable to process type for %s (%s). Expected %d fields on the structure. Received %d")
 
 	// Unauthorized (401 error)
-	Unauthorized = "Unauthorized"
+	Unauthorized = e(100192, "Unauthorized")
 
 	// WebhooksInvalidMsgHeaders missing headers section in the JSON/YAML posted
-	WebhooksInvalidMsgHeaders = "Invalid message - missing 'headers' (or not an object)"
+	WebhooksInvalidMsgHeaders = e(100193, "Invalid message - missing 'headers' (or not an object)")
 	// WebhooksInvalidMsgTypeMissing need to specify a msg type in the header
-	WebhooksInvalidMsgTypeMissing = "Invalid message - missing 'headers.type' (or not a string)"
+	WebhooksInvalidMsgTypeMissing = e(100194, "Invalid message - missing 'headers.type' (or not a string)")
 	// WebhooksInvalidMsgFromMissing need to specify a msg type in the header
-	WebhooksInvalidMsgFromMissing = "Invalid message - missing 'from' (or not a string)"
+	WebhooksInvalidMsgFromMissing = e(100195, "Invalid message - missing 'from' (or not a string)")
 	// WebhooksInvalidMsgType need to specify a valid msg type in the header
-	WebhooksInvalidMsgType = "Invalid message type: %s"
+	WebhooksInvalidMsgType = e(100196, "Invalid message type: %s")
 	// WebhooksKafkaUnexpectedErrFmt problem processing an error that came back from Kafka, so do a deep dump
-	WebhooksKafkaUnexpectedErrFmt = "Error did not contain message and metadata: %+v"
+	WebhooksKafkaUnexpectedErrFmt = e(100197, "Error did not contain message and metadata: %+v")
 	// WebhooksKafkaDeliveryReportNoMeta delivery reports should contain the metadata we set when we sent
-	WebhooksKafkaDeliveryReportNoMeta = "Sent message did not contain metadata: %+v"
+	WebhooksKafkaDeliveryReportNoMeta = e(100198, "Sent message did not contain metadata: %+v")
 	// WebhooksKafkaYAMLtoJSON re-serialization of webhook message into JSON failed
-	WebhooksKafkaYAMLtoJSON = "Unable to reserialize YAML payload as JSON: %s"
+	WebhooksKafkaYAMLtoJSON = e(100199, "Unable to reserialize YAML payload as JSON: %s")
 	// WebhooksKafkaErr wrapper on detailed error from Kafka itself
-	WebhooksKafkaErr = "Failed to deliver message to Kafka: %s"
+	WebhooksKafkaErr = e(100200, "Failed to deliver message to Kafka: %s")
 
 	// WebhooksDirectTooManyInflight when we're not using a buffered store (Kafka) we have to reject
-	WebhooksDirectTooManyInflight = "Too many in-flight transactions"
+	WebhooksDirectTooManyInflight = e(100201, "Too many in-flight transactions")
 	// WebhooksDirectBadHeaders problem processing for in-memory operation
-	WebhooksDirectBadHeaders = "Failed to process headers in message"
+	WebhooksDirectBadHeaders = e(100202, "Failed to process headers in message")
 
 	// LevelDBFailedRetriveOriginalKey problem retrieving entry - original key
-	LevelDBFailedRetriveOriginalKey = "Failed to retrieve the entry for the original key: %s. %s"
+	LevelDBFailedRetriveOriginalKey = e(100203, "Failed to retrieve the entry for the original key: %s. %s")
 	// LevelDBFailedRetriveGeneratedID problem retrieving entry - generated ID
-	LevelDBFailedRetriveGeneratedID = "Failed to retrieve the entry for the generated ID: %s. %s"
+	LevelDBFailedRetriveGeneratedID = e(100204, "Failed to retrieve the entry for the generated ID: %s. %s")
 
 	// WebSocketClosed websocket was closed
-	WebSocketClosed = "WebSocket '%s' closed"
+	WebSocketClosed = e(100205, "WebSocket '%s' closed")
 
 	// CircuitBreakerTripped is returned when the Kafka circuit breaker has deemed it unsafe to produce more messages
-	CircuitBreakerTripped = "Unable to send Kafka message as the gap of %d messages between consumer and producer is too large. Estimated at %.2fKb"
+	CircuitBreakerTripped = e(100206, "Unable to send Kafka message as the gap of %d messages between consumer and producer is too large. Estimated at %.2fKb")
+
+	// EventSupportNotConfiugred is returned when event support is not configured
+	EventSupportNotConfiugred = e(100207, "Event support is not configured on this gateway")
 )
 
-type Error string
+type EthconnectError interface {
+	Code() string
+	Error() string
+	ErrorNoCode() string
+	String() string
+}
 
-func (e Error) Error() string {
-	return string(e)
+type ethconnectError struct {
+	msg     *errorID
+	inserts []interface{}
+}
+
+func (e *ethconnectError) ErrorNoCode() string {
+	return fmt.Sprintf(e.msg.enMsg, e.inserts...)
+}
+
+func (e *ethconnectError) Error() string {
+	return fmt.Sprintf("%s: %s", e.msg.Code(), e.ErrorNoCode())
+}
+
+func (e *ethconnectError) Code() string {
+	return e.msg.Code()
+}
+
+func (e *ethconnectError) String() string {
+	return e.Error()
+}
+
+type RESTError struct {
+	Message string `json:"error"`
+	Code    string `json:"code,omitempty"`
+}
+
+func ToRESTError(err error) *RESTError {
+	var errorMessage string
+	var errorCode = ""
+	switch err := err.(type) {
+	case EthconnectError:
+		errorMessage = err.ErrorNoCode()
+		errorCode = err.Code()
+	default:
+		errorMessage = err.Error()
+	}
+	return &RESTError{Message: errorMessage, Code: errorCode}
 }
 
 // Errorf creates an error (not yet translated, but an extensible interface for that using simple sprintf formatting rather than named i18n inserts)
-func Errorf(msg ErrorID, inserts ...interface{}) error {
-	var err error = Error(fmt.Sprintf(string(msg), inserts...))
-	return errors.WithStack(err)
+func Errorf(msg ErrorID, inserts ...interface{}) EthconnectError {
+	return &ethconnectError{msg.(*errorID), inserts}
 }

--- a/internal/errors/errors_test.go
+++ b/internal/errors/errors_test.go
@@ -1,0 +1,56 @@
+// Copyright 2019 Kaleido
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package errors
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestToRESTErrorFFEC(t *testing.T) {
+
+	err := Errorf(ConfigFileReadFailed, "testfile.ext", fmt.Errorf("badness"))
+	assert.Equal(t, ConfigFileReadFailed.Code(), err.Code())
+	assert.Equal(t, "FFEC100003: Failed to read testfile.ext: badness", err.Error())
+	assert.Equal(t, "FFEC100003: Failed to read testfile.ext: badness", err.String())
+	restErr := ToRESTError(err)
+	assert.Equal(t, "Failed to read testfile.ext: badness", restErr.Message)
+	assert.Equal(t, "FFEC100003", restErr.Code)
+
+}
+
+func TestToRESTErrorOtherErr(t *testing.T) {
+
+	err := fmt.Errorf("some: %s", "badness")
+	assert.Equal(t, "some: badness", err.Error())
+	restErr := ToRESTError(err)
+	assert.Equal(t, "some: badness", restErr.Message)
+	assert.Empty(t, restErr.Code)
+
+}
+
+func TestDuplicate(t *testing.T) {
+	assert.Panics(t, func() {
+		e(100000, "dup")
+	})
+}
+
+func TestBadCode(t *testing.T) {
+	assert.Panics(t, func() {
+		e(0, "dup")
+	})
+}

--- a/internal/eth/compiler_test.go
+++ b/internal/eth/compiler_test.go
@@ -48,7 +48,7 @@ func TestPackContractFailBadHexCode(t *testing.T) {
 		Code: "Not Hex",
 	}
 	_, err := packContract("", contract)
-	assert.EqualError(err, "Decoding bytecode: hex string without 0x prefix")
+	assert.Regexp("Decoding bytecode: hex string without 0x prefix", err)
 }
 
 func TestPackContractEmpty(t *testing.T) {
@@ -57,7 +57,7 @@ func TestPackContractEmpty(t *testing.T) {
 		Code: "0x",
 	}
 	_, err := packContract("", contract)
-	assert.EqualError(err, "Specified contract compiled ok, but did not result in any bytecode: ")
+	assert.Regexp("Specified contract compiled ok, but did not result in any bytecode: ", err)
 }
 
 func TestPackContractFailMarshalABI(t *testing.T) {
@@ -69,7 +69,7 @@ func TestPackContractFailMarshalABI(t *testing.T) {
 		},
 	}
 	_, err := packContract("", contract)
-	assert.EqualError(err, "Serializing ABI: json: unsupported type: map[bool]bool")
+	assert.Regexp("Serializing ABI: json: unsupported type: map\\[bool\\]bool", err)
 }
 
 func TestPackContractFailUnmarshalABIJSON(t *testing.T) {
@@ -140,19 +140,19 @@ func TestSolcCustomVersionUnknown(t *testing.T) {
 	assert := assert.New(t)
 	defaultSolc = ""
 	_, err := getSolcExecutable("0.5")
-	assert.EqualError(err, "Could not find a configured compiler for requested Solidity major version 0.5")
+	assert.Regexp("Could not find a configured compiler for requested Solidity major version 0.5", err)
 }
 
 func TestSolcCustomVersionInvalid(t *testing.T) {
 	assert := assert.New(t)
 	defaultSolc = ""
 	_, err := getSolcExecutable("0.")
-	assert.EqualError(err, "Invalid Solidity version requested for compiler. Ensure the string starts with two dot separated numbers, such as 0.5")
+	assert.Regexp("Invalid Solidity version requested for compiler. Ensure the string starts with two dot separated numbers, such as 0.5", err)
 }
 
 func TestSolcCompileInvalidVersion(t *testing.T) {
 	assert := assert.New(t)
 	defaultSolc = ""
 	_, err := CompileContract("", "", "zero.four", "")
-	assert.EqualError(err, "Invalid Solidity version requested for compiler. Ensure the string starts with two dot separated numbers, such as 0.5")
+	assert.Regexp("Invalid Solidity version requested for compiler. Ensure the string starts with two dot separated numbers, such as 0.5", err)
 }

--- a/internal/eth/getreceipt_test.go
+++ b/internal/eth/getreceipt_test.go
@@ -76,7 +76,7 @@ func TestGetTXReceiptFail(t *testing.T) {
 
 	isMined, err := tx.GetTXReceipt(context.Background(), &r)
 
-	assert.EqualError(err, "eth_getTransactionReceipt returned: pop")
+	assert.Regexp("eth_getTransactionReceipt returned: pop", err)
 	assert.Equal("eth_getTransactionReceipt", r.capturedMethod)
 	assert.Equal(false, isMined)
 }
@@ -123,7 +123,7 @@ func TestGetTXReceiptOrionTXFail(t *testing.T) {
 
 	isMined, err := tx.GetTXReceipt(context.Background(), &r)
 
-	assert.EqualError(err, "priv_getTransactionReceipt returned: pop")
+	assert.Regexp("priv_getTransactionReceipt returned: pop", err)
 	assert.Equal("eth_getTransactionReceipt", r.capturedMethod)
 	assert.Equal("priv_getTransactionReceipt", r.capturedMethod2)
 	assert.Equal(false, isMined)

--- a/internal/eth/privacygroup_test.go
+++ b/internal/eth/privacygroup_test.go
@@ -84,7 +84,7 @@ func TestGetOrionPrivacyGroupErrFind(t *testing.T) {
 		"jO6dpqnMhmnrCHqUumyK09+18diF7quq/rROGs2HFWI=",
 		[]string{"2QiZG7rYPzRvRsioEn6oYUff1DOvPA22EZr0+/o3RUg="})
 
-	assert.EqualError(err, "priv_findPrivacyGroup returned: pop")
+	assert.Regexp("priv_findPrivacyGroup returned: pop", err)
 }
 
 func TestGetOrionPrivacyGroupErrCreate(t *testing.T) {
@@ -100,5 +100,5 @@ func TestGetOrionPrivacyGroupErrCreate(t *testing.T) {
 		"jO6dpqnMhmnrCHqUumyK09+18diF7quq/rROGs2HFWI=",
 		[]string{"2QiZG7rYPzRvRsioEn6oYUff1DOvPA22EZr0+/o3RUg="})
 
-	assert.EqualError(err, "priv_createPrivacyGroup returned: pop")
+	assert.Regexp("priv_createPrivacyGroup returned: pop", err)
 }

--- a/internal/eth/rpc_test.go
+++ b/internal/eth/rpc_test.go
@@ -132,9 +132,9 @@ func TestCallContextWrapperAuth(t *testing.T) {
 
 	w := &rpcWrapper{rpc: &mockEthClient{}}
 	_, err := w.Subscribe(context.Background(), "", nil)
-	assert.EqualError(err, "Unauthorized")
+	assert.Regexp("Unauthorized", err)
 	err = w.CallContext(context.Background(), nil, "")
-	assert.EqualError(err, "Unauthorized")
+	assert.Regexp("Unauthorized", err)
 
 	auth.RegisterSecurityModule(nil)
 }

--- a/internal/eth/txn.go
+++ b/internal/eth/txn.go
@@ -175,12 +175,12 @@ func DecodeInputs(method *ethbinding.ABIMethod, inputs *ethbinding.HexBytes) (ma
 	methodIDLen := len(method.ID)
 	expectedMethod := hex.EncodeToString(method.ID)
 	if len(*inputs) < methodIDLen {
-		return nil, fmt.Errorf(errors.TransactionQueryMethodMismatch, "unknown", expectedMethod)
+		return nil, errors.Errorf(errors.TransactionQueryMethodMismatch, "unknown", expectedMethod)
 	}
 	inputMethod := hex.EncodeToString((*inputs)[:methodIDLen])
 	if inputMethod != expectedMethod {
 		log.Infof("Method did not match: %s != %s", inputMethod, expectedMethod)
-		return nil, fmt.Errorf(errors.TransactionQueryMethodMismatch, inputMethod, expectedMethod)
+		return nil, errors.Errorf(errors.TransactionQueryMethodMismatch, inputMethod, expectedMethod)
 	}
 	return ProcessRLPBytes(method.Inputs, (*inputs)[methodIDLen:]), nil
 }
@@ -189,10 +189,10 @@ func GetTransactionInfo(ctx context.Context, rpc RPCClient, txHash string) (*Txn
 	log.Debugf("Retrieving transaction %s", txHash)
 	var txn TxnInfo
 	if err := rpc.CallContext(ctx, &txn, "eth_getTransactionByHash", txHash); err != nil {
-		return nil, fmt.Errorf(errors.RPCCallReturnedError, "eth_getTransactionByHash", err)
+		return nil, errors.Errorf(errors.RPCCallReturnedError, "eth_getTransactionByHash", err)
 	}
 	if txn.Input == nil {
-		return nil, fmt.Errorf(errors.TransactionQueryFailed, txHash)
+		return nil, errors.Errorf(errors.TransactionQueryFailed, txHash)
 	}
 	return &txn, nil
 }

--- a/internal/eth/txn_test.go
+++ b/internal/eth/txn_test.go
@@ -204,7 +204,7 @@ func TestNewContractDeployTxnSimpleStoragePrivateOrionMissingPrivateFrom(t *test
 	rpc := testRPCClient{}
 
 	err = tx.Send(context.Background(), &rpc)
-	assert.EqualError(err, "private-from is required when submitting private transactions via Orion")
+	assert.Regexp("private-from is required when submitting private transactions via Orion", err)
 }
 func TestNewContractDeployTxnSimpleStorageCalcGasFailAndCallSucceeds(t *testing.T) {
 	assert := assert.New(t)
@@ -222,7 +222,7 @@ func TestNewContractDeployTxnSimpleStorageCalcGasFailAndCallSucceeds(t *testing.
 
 	rpc.mockError = fmt.Errorf("pop")
 	err = tx.Send(context.Background(), &rpc)
-	assert.EqualError(err, "Failed to calculate gas for transaction: pop")
+	assert.Regexp("Failed to calculate gas for transaction: pop", err)
 }
 
 func TestNewContractDeployTxnSimpleStorageCalcGasFailAndCallFailsAsExpected(t *testing.T) {
@@ -242,7 +242,7 @@ func TestNewContractDeployTxnSimpleStorageCalcGasFailAndCallFailsAsExpected(t *t
 	rpc.mockError = fmt.Errorf("estimate gas fails")
 	rpc.mockError2 = fmt.Errorf("call fails")
 	err = tx.Send(context.Background(), &rpc)
-	assert.EqualError(err, "Call failed: call fails")
+	assert.Regexp("Call failed: call fails", err)
 }
 
 func TestNewContractDeployMissingCompiledOrSolidity(t *testing.T) {
@@ -256,7 +256,7 @@ func TestNewContractDeployMissingCompiledOrSolidity(t *testing.T) {
 	msg.Gas = "456"
 	msg.GasPrice = "789"
 	_, err := NewContractDeployTxn(&msg, nil)
-	assert.EqualError(err, "Missing Compiled Code + ABI, or Solidity")
+	assert.Regexp("Missing Compiled Code \\+ ABI, or Solidity", err)
 }
 
 func TestNewContractDeployPrecompiledSimpleStorage(t *testing.T) {
@@ -715,7 +715,7 @@ func TestSendTxnNilParam(t *testing.T) {
 	msg.Gas = "456"
 	msg.GasPrice = "789"
 	_, err := NewSendTxn(&msg, nil)
-	assert.EqualError(err, "Method 'testFunc' param 0: Cannot supply a null value")
+	assert.Regexp("Method 'testFunc' param 0: Cannot supply a null value", err)
 
 }
 
@@ -731,7 +731,7 @@ func TestNewSendTxnMissingParamTypes(t *testing.T) {
 		},
 		MethodName: "test",
 	}, nil)
-	assert.EqualError(err, "Param 0: supplied as an object must have 'type' and 'value' fields")
+	assert.Regexp("Param 0: supplied as an object must have 'type' and 'value' fields", err)
 }
 
 func TestCallMethod(t *testing.T) {
@@ -860,13 +860,13 @@ func TestCallMethodFail(t *testing.T) {
 		json.Number("12345"), method, params, "")
 
 	assert.Equal("eth_call", rpc.capturedMethod)
-	assert.EqualError(err, "Call failed: pop")
+	assert.Regexp("Call failed: pop", err)
 
 	_, err = CallMethod(context.Background(), rpc, nil,
 		"0xAA983AD2a0e0eD8ac639277F37be42F2A5d2618c",
 		"0x2b8c0ECc76d0759a8F50b2E14A6881367D805832",
 		json.Number("12345"), method, params, "ab2345")
-	assert.EqualError(err, "Invalid blocknumber. Failed to parse into big integer")
+	assert.Regexp("Invalid blocknumber. Failed to parse into big integer", err)
 }
 
 func TestCallMethodRevert(t *testing.T) {
@@ -890,7 +890,7 @@ func TestCallMethodRevert(t *testing.T) {
 		json.Number("12345"), method, params, "")
 
 	assert.Equal("eth_call", rpc.capturedMethod)
-	assert.EqualError(err, "Muppetry detected")
+	assert.Regexp("Muppetry detected", err)
 }
 
 func TestCallMethodRevertBadStrLen(t *testing.T) {
@@ -915,7 +915,7 @@ func TestCallMethodRevertBadStrLen(t *testing.T) {
 
 	assert.Equal("eth_call", rpc.capturedMethod)
 	// Should read up to the end of the padding, and not panic
-	assert.EqualError(err, "Muppetry detected\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00")
+	assert.Regexp("Muppetry detected\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00", err)
 }
 
 func TestCallMethodRevertBadBytes(t *testing.T) {
@@ -939,7 +939,7 @@ func TestCallMethodRevertBadBytes(t *testing.T) {
 		json.Number("12345"), method, params, "")
 
 	assert.Equal("eth_call", rpc.capturedMethod)
-	assert.EqualError(err, "EVM reverted. Failed to decode error message")
+	assert.Regexp("EVM reverted. Failed to decode error message", err)
 }
 
 func TestCallMethodBadArgs(t *testing.T) {
@@ -951,7 +951,7 @@ func TestCallMethodBadArgs(t *testing.T) {
 
 	_, err := CallMethod(context.Background(), rpc, nil, "badness", "", json.Number(""), &ethbinding.ABIMethod{}, []interface{}{}, "")
 
-	assert.EqualError(err, "Supplied value for 'from' is not a valid hex address")
+	assert.Regexp("Supplied value for 'from' is not a valid hex address", err)
 }
 
 func TestSendTxnNodeAssignNonce(t *testing.T) {
@@ -1091,7 +1091,7 @@ func TestSendWithTXSignerFail(t *testing.T) {
 	rpc := testRPCClient{}
 
 	err = tx.Send(context.Background(), &rpc)
-	assert.EqualError(err, "pop")
+	assert.Regexp("pop", err)
 }
 
 func TestSendWithTXSignerFailPrivate(t *testing.T) {
@@ -1121,7 +1121,7 @@ func TestSendWithTXSignerFailPrivate(t *testing.T) {
 	rpc := testRPCClient{}
 
 	err = tx.Send(context.Background(), &rpc)
-	assert.EqualError(err, "Signing with mock signer is not currently supported with private transactions")
+	assert.Regexp("Signing with mock signer is not currently supported with private transactions", err)
 }
 
 func TestNewContractWithTXSignerOK(t *testing.T) {
@@ -1205,7 +1205,7 @@ func TestSendTxnRPFError(t *testing.T) {
 	}
 
 	err = tx.Send(context.Background(), &rpc)
-	assert.EqualError(err, "pop")
+	assert.Regexp("pop", err)
 }
 
 func TestSendTxnInlineBadParamType(t *testing.T) {
@@ -1624,7 +1624,7 @@ func TestProcessRLPV2ABIEncodedStructsBadInputType(t *testing.T) {
 
 	tx := Txn{}
 	_, err = tx.generateTypedArgs([]interface{}{input1Map}, &abiMethod)
-	assert.EqualError(err, "Method 'inOutType1' param 0.nested is a (string,string,address,bytes): Must supply an object (supplied=string)")
+	assert.Regexp("Method 'inOutType1' param 0.nested is a \\(string,string,address,bytes\\): Must supply an object \\(supplied=string\\)", err)
 }
 
 func TestProcessRLPV2ABIEncodedStructsBadNilType(t *testing.T) {
@@ -1647,7 +1647,7 @@ func TestProcessRLPV2ABIEncodedStructsBadNilType(t *testing.T) {
 
 	tx := Txn{}
 	_, err = tx.generateTypedArgs([]interface{}{input1Map}, &abiMethod)
-	assert.EqualError(err, "Method inOutType1 param 0: supplied value '<nil>' could not be assigned to 'str1' field (string)")
+	assert.Regexp("Method inOutType1 param 0: supplied value '<nil>' could not be assigned to 'str1' field \\(string\\)", err)
 }
 
 func TestGenerateTupleFromMapBadStructType(t *testing.T) {
@@ -1660,14 +1660,14 @@ func TestGenerateTupleFromMapBadStructType(t *testing.T) {
 		TupleRawNames: []string{"field1"},
 		TupleElems:    []*ethbinding.ABIType{&tUint},
 	}, map[string]interface{}{"field1": float64(42)})
-	assert.EqualError(err, "Method method1 param test: supplied value '+42' could not be assigned to 'field1' field (uint256)")
+	assert.Regexp("Method method1 param test.*supplied value '\\+42' could not be assigned to 'field1' field \\(uint256\\)", err)
 }
 
 func TestGenTupleMapOutputBadTypeNonStruct(t *testing.T) {
 	assert := assert.New(t)
 	type random struct{ stuff string }
 	_, err := genTupleMapOutput("test", "random", &ethbinding.ABIType{TupleType: reflect.TypeOf((*string)(nil)).Elem()}, 42)
-	assert.EqualError(err, "Unable to process type for test (random). Expected string. Received 42")
+	assert.Regexp("Unable to process type for test \\(random\\). Expected string. Received 42", err)
 }
 
 func TestGenTupleMapOutputBadTypeCountMismatch(t *testing.T) {
@@ -1677,7 +1677,7 @@ func TestGenTupleMapOutputBadTypeCountMismatch(t *testing.T) {
 		TupleType:     reflect.TypeOf((*random)(nil)).Elem(),
 		TupleRawNames: []string{"field1", "field2"},
 	}, random{})
-	assert.EqualError(err, "Unable to process type for test (random). Expected 2 fields on the structure. Received 0")
+	assert.Regexp("Unable to process type for test \\(random\\). Expected 2 fields on the structure. Received 0", err)
 }
 
 func TestGenTupleMapOutputBadTypeValMismatch(t *testing.T) {
@@ -1689,7 +1689,7 @@ func TestGenTupleMapOutputBadTypeValMismatch(t *testing.T) {
 		TupleRawNames: []string{"field1"},
 		TupleElems:    []*ethbinding.ABIType{&tUint},
 	}, random{Field1: "stuff"})
-	assert.EqualError(err, "Expected number type in JSON/RPC response for test.field1 (uint256). Received string")
+	assert.Regexp("Expected number type in JSON/RPC response for test.field1 \\(uint256\\). Received string", err)
 }
 
 func TestProcessRLPBytesInvalidNumber(t *testing.T) {
@@ -1697,7 +1697,7 @@ func TestProcessRLPBytesInvalidNumber(t *testing.T) {
 
 	t1, _ := ethbind.API.ABITypeFor("int32")
 	_, err := mapOutput("test1", "int256", &t1, "not an int")
-	assert.EqualError(err, "Expected number type in JSON/RPC response for test1 (int256). Received string")
+	assert.Regexp("Expected number type in JSON/RPC response for test1 \\(int256\\). Received string", err)
 }
 
 func TestProcessRLPBytesInvalidBool(t *testing.T) {
@@ -1705,7 +1705,7 @@ func TestProcessRLPBytesInvalidBool(t *testing.T) {
 
 	t1, _ := ethbind.API.ABITypeFor("bool")
 	_, err := mapOutput("test1", "bool", &t1, "not a bool")
-	assert.EqualError(err, "Expected boolean type in JSON/RPC response for test1 (bool). Received string")
+	assert.Regexp("Expected boolean type in JSON/RPC response for test1 \\(bool\\). Received string", err)
 }
 
 func TestProcessRLPBytesInvalidString(t *testing.T) {
@@ -1713,7 +1713,7 @@ func TestProcessRLPBytesInvalidString(t *testing.T) {
 
 	t1, _ := ethbind.API.ABITypeFor("string")
 	_, err := mapOutput("test1", "string", &t1, 42)
-	assert.EqualError(err, "Expected string array type in JSON/RPC response for test1 (string). Received int")
+	assert.Regexp("Expected string array type in JSON/RPC response for test1 \\(string\\). Received int", err)
 }
 
 func TestProcessRLPBytesInvalidByteArray(t *testing.T) {
@@ -1721,7 +1721,7 @@ func TestProcessRLPBytesInvalidByteArray(t *testing.T) {
 
 	t1, _ := ethbind.API.ABITypeFor("address")
 	_, err := mapOutput("test1", "address", &t1, 42)
-	assert.EqualError(err, "Expected []byte type in JSON/RPC response for test1 (address). Received int")
+	assert.Regexp("Expected \\[\\]byte type in JSON/RPC response for test1 \\(address\\). Received int", err)
 }
 
 func TestProcessRLPBytesInvalidArray(t *testing.T) {
@@ -1729,7 +1729,7 @@ func TestProcessRLPBytesInvalidArray(t *testing.T) {
 
 	t1, _ := ethbind.API.ABITypeFor("int32[]")
 	_, err := mapOutput("test1", "int32[]", &t1, 42)
-	assert.EqualError(err, "Expected slice type in JSON/RPC response for test1 (int32[]). Received int")
+	assert.Regexp("Expected slice type in JSON/RPC response for test1 \\(int32\\[\\]\\). Received int", err)
 }
 
 func TestProcessRLPBytesInvalidArrayType(t *testing.T) {
@@ -1737,7 +1737,7 @@ func TestProcessRLPBytesInvalidArrayType(t *testing.T) {
 
 	t1, _ := ethbind.API.ABITypeFor("int32[]")
 	_, err := mapOutput("test1", "int32[]", &t1, []string{"wrong"})
-	assert.EqualError(err, "Expected number type in JSON/RPC response for test1[0] (int32[]). Received string")
+	assert.Regexp("Expected number type in JSON/RPC response for test1\\[0\\] \\(int32\\[\\]\\). Received string", err)
 }
 
 func TestProcessRLPBytesInvalidTypeByte(t *testing.T) {
@@ -1746,7 +1746,7 @@ func TestProcessRLPBytesInvalidTypeByte(t *testing.T) {
 	t1, _ := ethbind.API.ABITypeFor("bool")
 	t1.T = 42
 	_, err := mapOutput("test1", "randomness", &t1, 42)
-	assert.EqualError(err, "Unable to process type for test1 (randomness). Received int")
+	assert.Regexp("Unable to process type for test1 \\(randomness\\). Received int", err)
 }
 
 func TestProcessRLPBytesUnpackFailure(t *testing.T) {
@@ -1778,7 +1778,7 @@ func TestProcessOutputsTooFew(t *testing.T) {
 	}
 
 	err := processOutputs(methodABI.Outputs, []interface{}{}, make(map[string]interface{}))
-	assert.EqualError(err, "Expected 1 in JSON/RPC response. Received 0: []")
+	assert.Regexp("Expected 1 in JSON/RPC response. Received 0: \\[\\]", err)
 }
 
 func TestProcessOutputsTooMany(t *testing.T) {
@@ -1791,7 +1791,7 @@ func TestProcessOutputsTooMany(t *testing.T) {
 	}
 
 	err := processOutputs(methodABI.Outputs, []interface{}{"arg1"}, make(map[string]interface{}))
-	assert.EqualError(err, "Expected nil in JSON/RPC response. Received: [arg1]")
+	assert.Regexp("Expected nil in JSON/RPC response. Received: \\[arg1\\]", err)
 }
 
 func TestProcessOutputsDefaultName(t *testing.T) {
@@ -1826,7 +1826,7 @@ func TestProcessOutputsBadArgs(t *testing.T) {
 	}
 
 	err := processOutputs(methodABI.Outputs, []interface{}{"arg1"}, make(map[string]interface{}))
-	assert.EqualError(err, "Expected slice type in JSON/RPC response for retval1 (int32[]). Received string")
+	assert.Regexp("Expected slice type in JSON/RPC response for retval1 \\(int32\\[\\]\\). Received string", err)
 }
 
 func TestGetTransactionInfoFail(t *testing.T) {

--- a/internal/eth/txncount_test.go
+++ b/internal/eth/txncount_test.go
@@ -48,7 +48,7 @@ func TestGetTransactionCountErr(t *testing.T) {
 	addr := ethbind.API.HexToAddress("0xD50ce736021D9F7B0B2566a3D2FA7FA3136C003C")
 	_, err := GetTransactionCount(context.Background(), &r, &addr, "latest")
 
-	assert.EqualError(err, "eth_getTransactionCount returned: pop")
+	assert.Regexp("eth_getTransactionCount returned: pop", err)
 }
 
 func TestGetOrionPrivateTransactionCount(t *testing.T) {
@@ -75,5 +75,5 @@ func TestGetOrionPrivateTransactionCountErr(t *testing.T) {
 	addr := ethbind.API.HexToAddress("0xD50ce736021D9F7B0B2566a3D2FA7FA3136C003C")
 	_, err := GetOrionTXCount(context.Background(), &r, &addr, "negmDcN2P4ODpqn/6WkJ02zT/0w0bjhGpkZ8UP6vARk=")
 
-	assert.EqualError(err, "priv_getTransactionCount for privacy group 'negmDcN2P4ODpqn/6WkJ02zT/0w0bjhGpkZ8UP6vARk=' returned: pop")
+	assert.Regexp("priv_getTransactionCount for privacy group 'negmDcN2P4ODpqn/6WkJ02zT/0w0bjhGpkZ8UP6vARk=' returned: pop", err)
 }

--- a/internal/events/eventstream_test.go
+++ b/internal/events/eventstream_test.go
@@ -43,7 +43,7 @@ import (
 func TestConstructorNoSpec(t *testing.T) {
 	assert := assert.New(t)
 	_, err := newEventStream(newTestSubscriptionManager(), nil, nil)
-	assert.EqualError(err, "No ID")
+	assert.Regexp("No ID", err)
 }
 
 func TestConstructorBadType(t *testing.T) {
@@ -52,7 +52,7 @@ func TestConstructorBadType(t *testing.T) {
 		ID:   "123",
 		Type: "random",
 	}, nil)
-	assert.EqualError(err, "Unknown action type 'random'")
+	assert.Regexp("Unknown action type 'random'", err)
 }
 
 func TestConstructorMissingWebhook(t *testing.T) {
@@ -61,7 +61,7 @@ func TestConstructorMissingWebhook(t *testing.T) {
 		ID:   "123",
 		Type: "webhook",
 	}, nil)
-	assert.EqualError(err, "Must specify webhook.url for action type 'webhook'")
+	assert.Regexp("Must specify webhook.url for action type 'webhook'", err)
 }
 
 func TestConstructorBadWebhookURL(t *testing.T) {
@@ -73,7 +73,7 @@ func TestConstructorBadWebhookURL(t *testing.T) {
 			URL: ":badurl",
 		},
 	}, nil)
-	assert.EqualError(err, "Invalid URL in webhook action")
+	assert.Regexp("Invalid URL in webhook action", err)
 }
 
 func TestConstructorBadWebSocketDistributionMode(t *testing.T) {
@@ -86,7 +86,7 @@ func TestConstructorBadWebSocketDistributionMode(t *testing.T) {
 			DistributionMode: "banana",
 		},
 	}, nil)
-	assert.EqualError(err, "Invalid distribution mode 'banana'. Valid distribution modes are: 'workloadDistribution' and 'broadcast'.")
+	assert.Regexp("Invalid distribution mode 'banana'. Valid distribution modes are: 'workloadDistribution' and 'broadcast'.", err)
 }
 
 func testEvent(subID string) *eventData {
@@ -408,7 +408,7 @@ func TestWebSocketUnconfigured(t *testing.T) {
 	assert := assert.New(t)
 	sm := NewSubscriptionManager(&SubscriptionManagerConf{}, nil, nil, nil).(*subscriptionMGR)
 	_, err := sm.AddStream(context.Background(), &StreamInfo{Type: "websocket"})
-	assert.EqualError(err, "WebSocket listener not configured")
+	assert.Regexp("WebSocket listener not configured", err)
 }
 
 func TestBadTimestampCacheSize(t *testing.T) {
@@ -417,7 +417,7 @@ func TestBadTimestampCacheSize(t *testing.T) {
 	_, err := sm.AddStream(context.Background(), &StreamInfo{
 		TimestampCacheSize: -1,
 	})
-	assert.EqualError(err, "Failed to create a resource for the stream: must provide a positive size")
+	assert.Regexp("Failed to create a resource for the stream: must provide a positive size", err)
 }
 
 func setupTestSubscription(assert *assert.Assertions, sm *subscriptionMGR, stream *eventStream, subscriptionName string) *SubscriptionInfo {
@@ -1326,7 +1326,7 @@ func TestUpdateStreamSwapType(t *testing.T) {
 		},
 	}
 	_, err := sm.UpdateStream(ctx, stream.spec.ID, updateSpec)
-	assert.EqualError(err, "The type of an event stream cannot be changed")
+	assert.Regexp("The type of an event stream cannot be changed", err)
 }
 
 func TestUpdateStreamInProgress(t *testing.T) {
@@ -1378,7 +1378,7 @@ func TestUpdateWebSocketBadDistributionMode(t *testing.T) {
 		},
 	}
 	_, err := sm.UpdateStream(ctx, stream.spec.ID, updateSpec)
-	assert.EqualError(err, "Invalid distribution mode 'banana'. Valid distribution modes are: 'workloadDistribution' and 'broadcast'.")
+	assert.Regexp("Invalid distribution mode 'banana'. Valid distribution modes are: 'workloadDistribution' and 'broadcast'.", err)
 }
 
 func TestUpdateWebSocket(t *testing.T) {
@@ -1450,7 +1450,7 @@ func TestUpdateStreamMissingWebhookURL(t *testing.T) {
 		},
 	}
 	_, err := sm.UpdateStream(ctx, stream.spec.ID, updateSpec)
-	assert.EqualError(err, errors.EventStreamsWebhookNoURL)
+	assert.Regexp(errors.EventStreamsWebhookNoURL.Code(), err)
 	err = sm.DeleteSubscription(ctx, s.ID)
 	assert.NoError(err)
 	err = sm.DeleteStream(ctx, stream.spec.ID)
@@ -1495,7 +1495,7 @@ func TestUpdateStreamInvalidWebhookURL(t *testing.T) {
 		},
 	}
 	_, err := sm.UpdateStream(ctx, stream.spec.ID, updateSpec)
-	assert.EqualError(err, errors.EventStreamsWebhookInvalidURL)
+	assert.Regexp(errors.EventStreamsWebhookInvalidURL.Code(), err)
 	err = sm.DeleteSubscription(ctx, s.ID)
 	assert.NoError(err)
 	err = sm.DeleteStream(ctx, stream.spec.ID)

--- a/internal/events/logprocessor_test.go
+++ b/internal/events/logprocessor_test.go
@@ -117,7 +117,7 @@ func TestProcessLogEntryNillAndTooFewFields(t *testing.T) {
 		Topics: []*ethbinding.Hash{nil},
 	}, 2)
 
-	assert.EqualError(err, "ut: Ran out of topics for indexed fields at field 1 of testEvent(uint256,uint256)")
+	assert.Regexp("ut: Ran out of topics for indexed fields at field 1 of testEvent\\(uint256,uint256\\)", err)
 }
 
 func TestProcessLogBadRLPData(t *testing.T) {

--- a/internal/events/submanager_test.go
+++ b/internal/events/submanager_test.go
@@ -174,7 +174,7 @@ func TestActionAndSubscriptionLifecyle(t *testing.T) {
 	}
 
 	err = sm.ResumeStream(ctx, stream.ID)
-	assert.EqualError(err, "Event processor is already active. Suspending:false")
+	assert.Regexp("Event processor is already active. Suspending:false", err)
 
 	// Reload
 	sm.Close(false)
@@ -263,11 +263,11 @@ func TestStreamAndSubscriptionErrors(t *testing.T) {
 	assert.NoError(err)
 
 	err = sm.ResetSubscription(ctx, sub.ID, "badness")
-	assert.EqualError(err, "FromBlock cannot be parsed as a BigInt")
+	assert.Regexp("FromBlock cannot be parsed as a BigInt", err)
 
 	sm.db.Close()
 	err = sm.ResetSubscription(ctx, sub.ID, "0")
-	assert.EqualError(err, "Failed to store subscription: leveldb: closed")
+	assert.Regexp("Failed to store subscription: leveldb: closed", err)
 
 	close(blockCall)
 	sm.Close(true)
@@ -288,35 +288,35 @@ func TestResetSubscriptionErrors(t *testing.T) {
 
 	ctx := context.Background()
 	_, err := sm.AddStream(ctx, &StreamInfo{Type: "random"})
-	assert.EqualError(err, "Unknown action type 'random'")
+	assert.Regexp("Unknown action type 'random'", err)
 	_, err = sm.AddStream(ctx, &StreamInfo{
 		Type:    "webhook",
 		Webhook: &webhookActionInfo{URL: "http://test.invalid"},
 	})
-	assert.EqualError(err, "Failed to store stream: pop")
+	assert.Regexp("Failed to store stream: pop", err)
 	sm.streams["teststream"] = newTestStream()
 	err = sm.DeleteStream(ctx, "nope")
-	assert.EqualError(err, "Stream with ID 'nope' not found")
+	assert.Regexp("Stream with ID 'nope' not found", err)
 	err = sm.SuspendStream(ctx, "nope")
-	assert.EqualError(err, "Stream with ID 'nope' not found")
+	assert.Regexp("Stream with ID 'nope' not found", err)
 	err = sm.ResumeStream(ctx, "nope")
-	assert.EqualError(err, "Stream with ID 'nope' not found")
+	assert.Regexp("Stream with ID 'nope' not found", err)
 	err = sm.DeleteStream(ctx, "teststream")
-	assert.EqualError(err, "pop")
+	assert.Regexp("pop", err)
 
 	_, err = sm.AddSubscription(ctx, nil, nil, &ethbinding.ABIElementMarshaling{Name: "any"}, "nope", "", "")
-	assert.EqualError(err, "Stream with ID 'nope' not found")
+	assert.Regexp("Stream with ID 'nope' not found", err)
 	_, err = sm.AddSubscription(ctx, nil, nil, &ethbinding.ABIElementMarshaling{Name: "any"}, "teststream", "", "test")
-	assert.EqualError(err, "Failed to store subscription: pop")
+	assert.Regexp("Failed to store subscription: pop", err)
 	_, err = sm.AddSubscription(ctx, nil, nil, &ethbinding.ABIElementMarshaling{Name: "any"}, "teststream", "!bad integer", "")
-	assert.EqualError(err, "FromBlock cannot be parsed as a BigInt")
+	assert.Regexp("FromBlock cannot be parsed as a BigInt", err)
 	sm.subscriptions["testsub"] = &subscription{info: &SubscriptionInfo{}, rpc: sm.rpc}
 	err = sm.ResetSubscription(ctx, "nope", "0")
-	assert.EqualError(err, "Subscription with ID 'nope' not found")
+	assert.Regexp("Subscription with ID 'nope' not found", err)
 	err = sm.DeleteSubscription(ctx, "nope")
-	assert.EqualError(err, "Subscription with ID 'nope' not found")
+	assert.Regexp("Subscription with ID 'nope' not found", err)
 	err = sm.DeleteSubscription(ctx, "testsub")
-	assert.EqualError(err, "pop")
+	assert.Regexp("pop", err)
 }
 
 func TestRecoverErrors(t *testing.T) {

--- a/internal/events/subscription_test.go
+++ b/internal/events/subscription_test.go
@@ -143,7 +143,7 @@ func TestCreateSubscriptionNoEvent(t *testing.T) {
 	event := &ethbinding.ABIElementMarshaling{}
 	m := &mockSubMgr{stream: newTestStream()}
 	_, err := newSubscription(m, nil, nil, nil, testSubInfo(event))
-	assert.EqualError(err, "Solidity event name must be specified")
+	assert.Regexp("Solidity event name must be specified", err)
 }
 
 func TestCreateSubscriptionBadABI(t *testing.T) {
@@ -155,7 +155,7 @@ func TestCreateSubscriptionBadABI(t *testing.T) {
 	}
 	m := &mockSubMgr{stream: newTestStream()}
 	_, err := newSubscription(m, nil, nil, nil, testSubInfo(event))
-	assert.EqualError(err, "invalid type '-1'")
+	assert.Regexp("invalid type '-1'", err)
 }
 
 func TestCreateSubscriptionMissingAction(t *testing.T) {
@@ -163,14 +163,14 @@ func TestCreateSubscriptionMissingAction(t *testing.T) {
 	event := &ethbinding.ABIElementMarshaling{Name: "party"}
 	m := &mockSubMgr{err: fmt.Errorf("nope")}
 	_, err := newSubscription(m, nil, nil, nil, testSubInfo(event))
-	assert.EqualError(err, "nope")
+	assert.Regexp("nope", err)
 }
 
 func TestRestoreSubscriptionMissingAction(t *testing.T) {
 	assert := assert.New(t)
 	m := &mockSubMgr{err: fmt.Errorf("nope")}
 	_, err := restoreSubscription(m, nil, nil, testSubInfo(&ethbinding.ABIElementMarshaling{}))
-	assert.EqualError(err, "nope")
+	assert.Regexp("nope", err)
 }
 
 func TestRestoreSubscriptionBadType(t *testing.T) {
@@ -182,7 +182,7 @@ func TestRestoreSubscriptionBadType(t *testing.T) {
 	}
 	m := &mockSubMgr{stream: newTestStream()}
 	_, err := restoreSubscription(m, nil, nil, testSubInfo(event))
-	assert.EqualError(err, "invalid type '-1'")
+	assert.Regexp("invalid type '-1'", err)
 }
 
 func TestProcessEventsStaleFilter(t *testing.T) {
@@ -193,7 +193,7 @@ func TestProcessEventsStaleFilter(t *testing.T) {
 	rpc.On("CallContext", mock.Anything, mock.Anything, "eth_uninstallFilter", mock.Anything).Return(nil)
 	s := &subscription{rpc: rpc}
 	err := s.processNewEvents(context.Background())
-	assert.EqualError(err, "filter not found")
+	assert.Regexp("filter not found", err)
 	assert.True(s.filterStale)
 }
 
@@ -229,7 +229,7 @@ func TestInitialFilterFail(t *testing.T) {
 		rpc:  rpc,
 	}
 	_, err := s.setInitialBlockHeight(context.Background())
-	assert.EqualError(err, "eth_blockNumber returned: pop")
+	assert.Regexp("eth_blockNumber returned: pop", err)
 	rpc.AssertExpectations(t)
 }
 
@@ -242,7 +242,7 @@ func TestInitialFilterBadInitialBlock(t *testing.T) {
 		rpc: &ethmocks.RPCClient{},
 	}
 	_, err := s.setInitialBlockHeight(context.Background())
-	assert.EqualError(err, "FromBlock cannot be parsed as a BigInt")
+	assert.Regexp("FromBlock cannot be parsed as a BigInt", err)
 }
 
 func TestInitialFilterCustomInitialBlock(t *testing.T) {
@@ -270,7 +270,7 @@ func TestRestartFilterFail(t *testing.T) {
 		rpc:  rpc,
 	}
 	err := s.restartFilter(context.Background(), big.NewInt(0))
-	assert.EqualError(err, "eth_blockNumber returned: pop")
+	assert.Regexp("eth_blockNumber returned: pop", err)
 	rpc.AssertExpectations(t)
 }
 
@@ -284,7 +284,7 @@ func TestCreateFilterFail(t *testing.T) {
 		rpc:  rpc,
 	}
 	err := s.createFilter(context.Background(), big.NewInt(0))
-	assert.EqualError(err, "eth_newFilter returned: pop")
+	assert.Regexp("eth_newFilter returned: pop", err)
 	rpc.AssertExpectations(t)
 }
 
@@ -299,7 +299,7 @@ func TestProcessCatchupBlocksFail(t *testing.T) {
 		catchupBlock: big.NewInt(12345),
 	}
 	err := s.processCatchupBlocks(context.Background())
-	assert.EqualError(err, "eth_getLogs returned: pop")
+	assert.Regexp("eth_getLogs returned: pop", err)
 	rpc.AssertExpectations(t)
 }
 

--- a/internal/kafka/kafkabridge_test.go
+++ b/internal/kafka/kafkabridge_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/Shopify/sarama"
 	"github.com/hyperledger/firefly-ethconnect/internal/auth"
 	"github.com/hyperledger/firefly-ethconnect/internal/auth/authtest"
+	"github.com/hyperledger/firefly-ethconnect/internal/errors"
 	"github.com/hyperledger/firefly-ethconnect/internal/eth"
 	"github.com/hyperledger/firefly-ethconnect/internal/messages"
 	"github.com/hyperledger/firefly-ethconnect/internal/tx"
@@ -125,7 +126,7 @@ func TestExecuteBridgeWithIncompleteArgs(t *testing.T) {
 
 	kafkaCmd.SetArgs(testArgs)
 	err := kafkaCmd.Execute()
-	assert.Equal(err.Error(), "No JSON/RPC URL set for ethereum node")
+	assert.Regexp("No JSON/RPC URL set for ethereum node", err)
 	testArgs = append(testArgs, []string{"-r", "http://localhost:8545"}...)
 
 	testArgs = append(testArgs, []string{"--tx-timeout", "1"}...)
@@ -320,6 +321,7 @@ func TestSingleMessageWithNotAuthorizedReply(t *testing.T) {
 		return
 	}
 	assert.Equal("Unauthorized", errorReply.ErrorMessage)
+	assert.Equal(errors.Unauthorized.Code(), errorReply.ErrorCode)
 
 	// Shut down
 	mockProducer.AsyncClose()

--- a/internal/kafka/kafkacommon_test.go
+++ b/internal/kafka/kafkacommon_test.go
@@ -121,25 +121,25 @@ func TestExecuteWithIncompleteArgs(t *testing.T) {
 
 	testArgs := []string{}
 	_, err := execKafkaCommonWithArgs(assert, testArgs, f)
-	assert.Equal("No output topic specified for bridge to send events to", err.Error())
+	assert.Regexp("No output topic specified for bridge to send events to", err.Error())
 	testArgs = append(testArgs, []string{"-T", "test"}...)
 
 	_, err = execKafkaCommonWithArgs(assert, testArgs, f)
-	assert.Equal("No input topic specified for bridge to listen to", err.Error())
+	assert.Regexp("No input topic specified for bridge to listen to", err.Error())
 	testArgs = append(testArgs, []string{"-t", "test-in"}...)
 
 	_, err = execKafkaCommonWithArgs(assert, testArgs, f)
-	assert.Equal("No consumer group specified", err.Error())
+	assert.Regexp("No consumer group specified", err.Error())
 	testArgs = append(testArgs, []string{"-g", "test-group"}...)
 
 	testArgs = append(testArgs, []string{"-b", "broker1", "--tls-clientcerts", "/some/file"}...)
 	_, err = execKafkaCommonWithArgs(assert, testArgs, f)
-	assert.Equal("Client private key and certificate must both be provided for mutual auth", err.Error())
+	assert.Regexp("Client private key and certificate must both be provided for mutual auth", err.Error())
 	testArgs = append(testArgs, []string{"--tls-clientkey", "somekey"}...)
 
 	testArgs = append(testArgs, []string{"--sasl-username", "testuser"}...)
 	_, err = execKafkaCommonWithArgs(assert, testArgs, f)
-	assert.Equal("Username and Password must both be provided for SASL", err.Error())
+	assert.Regexp("Username and Password must both be provided for SASL", err.Error())
 
 }
 
@@ -245,7 +245,7 @@ func TestMissingBroker(t *testing.T) {
 		"-i", "clientid1",
 	}, f)
 
-	assert.EqualError(err, "No Kafka brokers configured")
+	assert.Regexp("No Kafka brokers configured", err)
 
 }
 

--- a/internal/kvstore/memkv_test.go
+++ b/internal/kvstore/memkv_test.go
@@ -30,7 +30,7 @@ func TestExerciseMockLDB(t *testing.T) {
 	assert.Equal("val", string(o2))
 	m.Delete("test")
 	_, err := m.Get("test")
-	assert.EqualError(err, "leveldb: not found")
+	assert.Regexp("leveldb: not found", err)
 	m.NewIterator()
 	m.Close()
 

--- a/internal/messages/messages_test.go
+++ b/internal/messages/messages_test.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hyperledger/firefly-ethconnect/internal/errors"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -66,6 +67,18 @@ func TestJSONEncodingAssumptions(t *testing.T) {
 	assert.Equal("pop", unmarshaledErrMsg.ErrorMessage)
 	assert.NotEmpty(unmarshaledErrMsg.OriginalMessage)
 
+}
+
+func TestNewErrorReplyFFEC(t *testing.T) {
+	errReply := NewErrorReply(errors.Errorf(errors.Unauthorized), map[string]interface{}{})
+	assert.Equal(t, errors.Unauthorized.Code(), errReply.ErrorCode)
+	assert.Equal(t, "Unauthorized", errReply.ErrorMessage)
+}
+
+func TestNewErrorReplyNonFFEC(t *testing.T) {
+	errReply := NewErrorReply(fmt.Errorf("non FFEC error"), map[string]interface{}{})
+	assert.Empty(t, errReply.ErrorCode)
+	assert.Equal(t, "non FFEC error", errReply.ErrorMessage)
 }
 
 func TestErrorMessageForEmptyData(t *testing.T) {

--- a/internal/rest/leveldbreceipt_test.go
+++ b/internal/rest/leveldbreceipt_test.go
@@ -147,7 +147,7 @@ func TestLevelDBReceiptsAddReceiptFailed(t *testing.T) {
 
 	receipt := make(map[string]interface{})
 	err := r.AddReceipt("key", &receipt)
-	assert.EqualError(err, "pop")
+	assert.Regexp("pop", err)
 }
 
 func TestLevelDBReceiptsGetReceiptsOK(t *testing.T) {
@@ -522,7 +522,7 @@ func TestLevelDBReceiptsGetReceiptErrorID(t *testing.T) {
 	}
 
 	_, err := r.GetReceipt("receipt1")
-	assert.EqualError(err, "Failed to retrieve the entry for the original key: receipt1. pop")
+	assert.Regexp("Failed to retrieve the entry for the original key: receipt1. pop", err)
 }
 
 func TestLevelDBReceiptsGetReceiptErrorGeneratedID(t *testing.T) {
@@ -539,7 +539,7 @@ func TestLevelDBReceiptsGetReceiptErrorGeneratedID(t *testing.T) {
 	}
 
 	_, err := r.GetReceipt("receipt1")
-	assert.EqualError(err, "Failed to retrieve the entry for the generated ID: receipt1. pop")
+	assert.Regexp("Failed to retrieve the entry for the generated ID: receipt1. pop", err)
 }
 
 func TestLevelDBReceiptsGetReceiptBadDataID(t *testing.T) {

--- a/internal/rest/leveldbreceipts.go
+++ b/internal/rest/leveldbreceipts.go
@@ -211,7 +211,7 @@ func (l *levelDBReceipts) GetReceipt(requestID string) (*map[string]interface{},
 	content, err := l.store.Get(lookupKey)
 	if err != nil {
 		log.Errorf("Failed to retrieve the entry using the generated ID: %s. %s\n", lookupKey, err)
-		return nil, fmt.Errorf(errors.LevelDBFailedRetriveGeneratedID, requestID, err)
+		return nil, errors.Errorf(errors.LevelDBFailedRetriveGeneratedID, requestID, err)
 	}
 
 	result := make(map[string]interface{})

--- a/internal/rest/memreceipts_test.go
+++ b/internal/rest/memreceipts_test.go
@@ -54,5 +54,5 @@ func TestMemReceiptsNoIDFilterImpl(t *testing.T) {
 	r := newMemoryReceipts(conf)
 
 	_, err := r.GetReceipts(0, 0, []string{"test"}, 0, "t", "t", "")
-	assert.EqualError(err, "Memory receipts do not support filtering")
+	assert.Regexp("Memory receipts do not support filtering", err)
 }

--- a/internal/rest/mongoreceipts_test.go
+++ b/internal/rest/mongoreceipts_test.go
@@ -150,7 +150,7 @@ func TestMongoReceiptsConnectConnErr(t *testing.T) {
 	}
 
 	err := r.connect()
-	assert.EqualError(err, "Unable to connect to MongoDB: pop")
+	assert.Regexp("Unable to connect to MongoDB: pop", err)
 }
 
 func TestMongoReceiptsConnectCollErr(t *testing.T) {
@@ -178,7 +178,7 @@ func TestMongoReceiptsConnectIdxErr(t *testing.T) {
 	}
 
 	err := r.connect()
-	assert.EqualError(err, "Unable to create index: pop")
+	assert.Regexp("Unable to create index: pop", err)
 }
 
 func TestMongoReceiptsAddReceiptOK(t *testing.T) {
@@ -209,7 +209,7 @@ func TestMongoReceiptsAddReceiptFailed(t *testing.T) {
 	r.connect()
 	receipt := make(map[string]interface{})
 	err := r.AddReceipt("key", &receipt)
-	assert.EqualError(err, "pop")
+	assert.Regexp("pop", err)
 }
 
 func TestMongoReceiptsGetReceiptsOK(t *testing.T) {
@@ -304,7 +304,7 @@ func TestMongoReceiptsGetReceiptsError(t *testing.T) {
 
 	r.connect()
 	_, err := r.GetReceipts(5, 2, nil, 0, "", "", "")
-	assert.EqualError(err, "pop")
+	assert.Regexp("pop", err)
 }
 
 func TestMongoReceiptsGetReceiptOK(t *testing.T) {
@@ -361,5 +361,5 @@ func TestMongoReceiptsGetReceiptError(t *testing.T) {
 
 	r.connect()
 	_, err := r.GetReceipt("receipt1")
-	assert.EqualError(err, "pop")
+	assert.Regexp("pop", err)
 }

--- a/internal/rest/receiptstore_test.go
+++ b/internal/rest/receiptstore_test.go
@@ -475,7 +475,7 @@ func TestGetRepliesCustomFiltersISO(t *testing.T) {
 	status, resObj, httpErr := testGETObject(ts, "/replies?from=abc&to=bcd&since=2019-01-01T00:00:00Z")
 	assert.NoError(httpErr)
 	assert.Equal(500, status)
-	assert.Equal("Error querying replies: Memory receipts do not support filtering", resObj["error"])
+	assert.Regexp("Error querying replies.*Memory receipts do not support filtering", resObj["error"])
 }
 
 func TestGetRepliesCustomFiltersTS(t *testing.T) {
@@ -492,7 +492,7 @@ func TestGetRepliesCustomFiltersTS(t *testing.T) {
 	status, resObj, httpErr := testGETObject(ts, "/replies?from=abc&to=bcd&since=1580435959")
 	assert.NoError(httpErr)
 	assert.Equal(500, status)
-	assert.Equal("Error querying replies: Memory receipts do not support filtering", resObj["error"])
+	assert.Regexp("Error querying replies.*Memory receipts do not support filtering", resObj["error"])
 }
 
 func TestGetRepliesBadSinceTS(t *testing.T) {

--- a/internal/rest/resterror.go
+++ b/internal/rest/resterror.go
@@ -18,15 +18,12 @@ import (
 	"encoding/json"
 	"net/http"
 
+	"github.com/hyperledger/firefly-ethconnect/internal/errors"
 	log "github.com/sirupsen/logrus"
 )
 
-type restError struct {
-	Message string `json:"error"`
-}
-
 func sendRESTError(res http.ResponseWriter, req *http.Request, err error, status int) {
-	reply, _ := json.Marshal(&restError{Message: err.Error()})
+	reply, _ := json.Marshal(errors.ToRESTError(err))
 	log.Errorf("<-- %s %s [%d]: %s", req.Method, req.URL, status, err)
 	res.Header().Set("Content-Type", "application/json")
 	res.WriteHeader(status)

--- a/internal/rest/restgateway_test.go
+++ b/internal/rest/restgateway_test.go
@@ -49,7 +49,7 @@ func TestValidateConfInvalidArgs(t *testing.T) {
 	g := NewRESTGateway(&printYAML)
 	g.conf.MongoDB.URL = "mongodb://localhost:27017"
 	err := g.ValidateConf()
-	assert.EqualError(err, "MongoDB URL, Database and Collection name must be specified to enable the receipt store")
+	assert.Regexp("MongoDB URL, Database and Collection name must be specified to enable the receipt store", err)
 }
 
 func TestValidateConfInvalidOpenAPIArgs(t *testing.T) {
@@ -58,7 +58,7 @@ func TestValidateConfInvalidOpenAPIArgs(t *testing.T) {
 	g := NewRESTGateway(&printYAML)
 	g.conf.OpenAPI.StoragePath = "/tmp/t"
 	err := g.ValidateConf()
-	assert.EqualError(err, "RPC URL and Storage Path must be supplied to enable the Open API REST Gateway")
+	assert.Regexp("RPC URL and Storage Path must be supplied to enable the Open API REST Gateway", err)
 }
 
 func TestStartStatusStopNoKafkaWebhooksAccessToken(t *testing.T) {
@@ -106,7 +106,7 @@ func TestStartStatusStopNoKafkaWebhooksAccessToken(t *testing.T) {
 
 	g.srv.Close()
 	wg.Wait()
-	assert.EqualError(err, "http: Server closed")
+	assert.Regexp("http: Server closed", err)
 
 	auth.RegisterSecurityModule(nil)
 
@@ -158,7 +158,7 @@ func TestStartStatusStopNoKafkaWebhooksMissingToken(t *testing.T) {
 
 	g.srv.Close()
 	wg.Wait()
-	assert.EqualError(err, "http: Server closed")
+	assert.Regexp("http: Server closed", err)
 
 	auth.RegisterSecurityModule(nil)
 
@@ -182,7 +182,7 @@ func TestStartWithKafkaWebhooks(t *testing.T) {
 	}()
 
 	wg.Wait()
-	assert.EqualError(err, "No Kafka brokers configured")
+	assert.Regexp("No Kafka brokers configured", err)
 }
 
 func TestStartWithBadTLS(t *testing.T) {
@@ -204,7 +204,7 @@ func TestStartWithBadTLS(t *testing.T) {
 	}()
 
 	wg.Wait()
-	assert.EqualError(err, "Client private key and certificate must both be provided for mutual auth")
+	assert.Regexp("Client private key and certificate must both be provided for mutual auth", err)
 }
 
 func TestStartInvalidMongo(t *testing.T) {
@@ -221,7 +221,7 @@ func TestStartInvalidMongo(t *testing.T) {
 	g.conf.MongoDB.URL = url.String()
 	g.conf.MongoDB.ConnectTimeoutMS = 100
 	err := g.Start()
-	assert.EqualError(err, "Unable to connect to MongoDB: no reachable servers")
+	assert.Regexp("Unable to connect to MongoDB: no reachable servers", err)
 }
 
 func TestStartWithBadRPCUrl(t *testing.T) {
@@ -242,7 +242,7 @@ func TestStartWithBadRPCUrl(t *testing.T) {
 	}()
 
 	wg.Wait()
-	assert.EqualError(err, "JSON/RPC connection to  failed: dial unix: missing address")
+	assert.Regexp("JSON/RPC connection to  failed: dial unix: missing address", err)
 }
 func TestPrintYaml(t *testing.T) {
 	assert := assert.New(t)
@@ -265,7 +265,7 @@ func TestMissingRPCAndMissingKafka(t *testing.T) {
 	cmd := g.CobraInit("rest")
 	cmd.SetArgs([]string{"-l", "8001"})
 	err := cmd.Execute()
-	assert.EqualError(err, "No JSON/RPC URL set for ethereum node")
+	assert.Regexp("No JSON/RPC URL set for ethereum node", err)
 }
 
 func TestMaxWaitTimeTooSmallWarns(t *testing.T) {
@@ -313,7 +313,7 @@ func TestKafkaCobraInitFailure(t *testing.T) {
 	cmd.SetArgs(args)
 	cmd.ParseFlags(args)
 	err := cmd.PreRunE(cmd, args)
-	assert.EqualError(err, "No output topic specified for bridge to send events to")
+	assert.Regexp("No output topic specified for bridge to send events to", err)
 	assert.Equal([]string{"broker1", "broker2"}, g.conf.Kafka.Brokers)
 }
 
@@ -328,5 +328,5 @@ func TestDispatchMsgAsyncPassesThroughToWebhooks(t *testing.T) {
 
 	var fakeMsg map[string]interface{}
 	_, err := g.DispatchMsgAsync(context.Background(), fakeMsg, true, true)
-	assert.EqualError(err, "Invalid message - missing 'headers' (or not an object)")
+	assert.Regexp("Invalid message - missing 'headers' \\(or not an object\\)", err)
 }

--- a/internal/rest/webhooks_test.go
+++ b/internal/rest/webhooks_test.go
@@ -188,7 +188,7 @@ func TestContractGWHandlerUnmarshalFail(t *testing.T) {
 	_, err := w.contractGWHandler(map[string]interface{}{
 		"bad json": map[bool]bool{true: false},
 	})
-	assert.EqualError(err, "unexpected end of JSON input")
+	assert.Regexp("unexpected end of JSON input", err)
 }
 
 func TestWebhookHandlerTransaction(t *testing.T) {

--- a/internal/rest/webhooksdirect_test.go
+++ b/internal/rest/webhooksdirect_test.go
@@ -161,7 +161,7 @@ func TestWebhooksDirectSendWebhooksMsgBadHeaders(t *testing.T) {
 	msgMap["headers"] = false
 	_, statusCode, err := wd.sendWebhookMsg(context.Background(), "", "", msgMap, false)
 	assert.Equal(400, statusCode)
-	assert.EqualError(err, "Failed to process headers in message")
+	assert.Regexp("Failed to process headers in message", err)
 }
 
 func TestWebhooksDirectUnmarshalBadMsg(t *testing.T) {
@@ -170,5 +170,5 @@ func TestWebhooksDirectUnmarshalBadMsg(t *testing.T) {
 	ctx := &msgContext{msg: msg}
 	msg["bad"] = map[bool]string{}
 	err := ctx.Unmarshal(nil)
-	assert.EqualError(err, "json: unsupported type: map[bool]string")
+	assert.Regexp("json: unsupported type: map\\[bool\\]string", err)
 }

--- a/internal/rest/webhookskafka_test.go
+++ b/internal/rest/webhookskafka_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/Shopify/sarama"
 	"github.com/hyperledger/firefly-ethconnect/internal/auth"
 	"github.com/hyperledger/firefly-ethconnect/internal/auth/authtest"
+	"github.com/hyperledger/firefly-ethconnect/internal/errors"
 	"github.com/hyperledger/firefly-ethconnect/internal/kafka"
 	"github.com/hyperledger/firefly-ethconnect/internal/messages"
 	"github.com/julienschmidt/httprouter"
@@ -137,7 +138,7 @@ func assertSentResp(assert *assert.Assertions, resp *http.Response, ack bool) {
 			assert.NotEmpty(replyMsg.Msg)
 		}
 	} else {
-		var replyMsg restError
+		var replyMsg errors.RESTError
 		err = json.Unmarshal(replyBytes, &replyMsg)
 		assert.Nil(err)
 		log.Errorf("Error from server: %s", replyMsg.Message)
@@ -148,7 +149,7 @@ func assertErrResp(assert *assert.Assertions, resp *http.Response, status int, m
 	assert.Equal(status, resp.StatusCode)
 	replyBytes, err := ioutil.ReadAll(resp.Body)
 	assert.Nil(err)
-	var replyMsg restError
+	var replyMsg errors.RESTError
 	err = json.Unmarshal(replyBytes, &replyMsg)
 	assert.Nil(err)
 	assert.Regexp(msg, replyMsg.Message)

--- a/internal/tx/addressbook_test.go
+++ b/internal/tx/addressbook_test.go
@@ -131,7 +131,7 @@ func TestLookupBadURL(t *testing.T) {
 	ctx := context.Background()
 	_, err := ab.lookup(ctx, "0xdb0997dccd71607bd6ee378723a12ef8478e4ed6")
 
-	assert.EqualError(err, "Invalid URL obtained for address")
+	assert.Regexp("Invalid URL obtained for address", err)
 }
 
 func TestLookupFallbackAddress(t *testing.T) {
@@ -191,7 +191,7 @@ func TestLookupNoFallbackAddress(t *testing.T) {
 	ctx := context.Background()
 	_, err := ab.lookup(ctx, "0xdb0997dccd71607bd6ee378723a12ef8478e4ed6")
 
-	assert.EqualError(err, "Unknown address")
+	assert.Regexp("Unknown address", err)
 
 }
 
@@ -220,7 +220,7 @@ func TestLookupBadResponse(t *testing.T) {
 	ctx := context.Background()
 	_, err := ab.lookup(ctx, "0xdb0997dccd71607bd6ee378723a12ef8478e4ed6")
 
-	assert.EqualError(err, "'rpcEndpointProp' missing in Addressbook response")
+	assert.Regexp("'rpcEndpointProp' missing in Addressbook response", err)
 
 }
 
@@ -247,7 +247,7 @@ func TestLookupFailureResponse(t *testing.T) {
 	log.SetLevel(log.DebugLevel)
 	_, err := ab.lookup(context.Background(), "0xdb0997dccd71607bd6ee378723a12ef8478e4ed6")
 
-	assert.EqualError(err, "Could not process Addressbook [500] response")
+	assert.Regexp("Could not process Addressbook \\[500\\] response", err)
 
 }
 

--- a/internal/tx/hdwallet_test.go
+++ b/internal/tx/hdwallet_test.go
@@ -103,7 +103,7 @@ func TestHDWalletSignerForRequestFail(t *testing.T) {
 	}).(*hdWallet)
 
 	_, err := hd.SignerFor(hdr)
-	assert.EqualError(err, "HDWallet signing failed")
+	assert.Regexp("HDWallet signing failed", err)
 }
 
 func TestHDWalletSignerForEmptyResponse(t *testing.T) {
@@ -124,7 +124,7 @@ func TestHDWalletSignerForEmptyResponse(t *testing.T) {
 	}).(*hdWallet)
 
 	_, err := hd.SignerFor(hdr)
-	assert.EqualError(err, "Unexpected response from HDWallet")
+	assert.Regexp("Unexpected response from HDWallet", err)
 }
 
 func TestHDWalletSignerBadAddress(t *testing.T) {
@@ -145,7 +145,7 @@ func TestHDWalletSignerBadAddress(t *testing.T) {
 	}).(*hdWallet)
 
 	_, err := hd.SignerFor(hdr)
-	assert.EqualError(err, "Unexpected response from HDWallet")
+	assert.Regexp("Unexpected response from HDWallet", err)
 }
 
 func TestHDWalletSignerBadKeyType(t *testing.T) {
@@ -166,7 +166,7 @@ func TestHDWalletSignerBadKeyType(t *testing.T) {
 	}).(*hdWallet)
 
 	_, err := hd.SignerFor(hdr)
-	assert.EqualError(err, "Unexpected response from HDWallet")
+	assert.Regexp("Unexpected response from HDWallet", err)
 }
 
 func TestHDWalletSignerBadKey(t *testing.T) {
@@ -187,5 +187,5 @@ func TestHDWalletSignerBadKey(t *testing.T) {
 	}).(*hdWallet)
 
 	_, err := hd.SignerFor(hdr)
-	assert.EqualError(err, "Unexpected response from HDWallet")
+	assert.Regexp("Unexpected response from HDWallet", err)
 }

--- a/internal/tx/txnprocessor_test.go
+++ b/internal/tx/txnprocessor_test.go
@@ -243,7 +243,7 @@ func TestOnDeployContractMessageBadMsg(t *testing.T) {
 
 	assert.NotEmpty(testTxnContext.errorReplies)
 	assert.Empty(testTxnContext.replies)
-	assert.Equal("Missing Compiled Code + ABI, or Solidity", testTxnContext.errorReplies[0].err.Error())
+	assert.Regexp("Missing Compiled Code \\+ ABI, or Solidity", testTxnContext.errorReplies[0].err.Error())
 
 }
 func TestOnDeployContractMessageBadJSON(t *testing.T) {
@@ -595,7 +595,7 @@ func TestOnDeployContractMessageFailedToGetNonce(t *testing.T) {
 		time.Sleep(1 * time.Millisecond)
 	}
 
-	assert.Equal("eth_getTransactionCount returned: ding", testTxnContext.errorReplies[0].err.Error())
+	assert.Regexp("eth_getTransactionCount returned: ding", testTxnContext.errorReplies[0].err.Error())
 	assert.EqualValues([]string{"eth_getTransactionCount"}, testRPC.calls)
 }
 
@@ -876,7 +876,7 @@ func TestOnSendTransactionMessageFailedToGetNonce(t *testing.T) {
 		time.Sleep(1 * time.Millisecond)
 	}
 
-	assert.Equal("eth_getTransactionCount returned: poof", testTxnContext.errorReplies[0].err.Error())
+	assert.Regexp("eth_getTransactionCount returned: poof", testTxnContext.errorReplies[0].err.Error())
 	assert.EqualValues([]string{"eth_getTransactionCount"}, testRPC.calls)
 }
 
@@ -1176,7 +1176,7 @@ func TestOnSendTransactionAddressBook(t *testing.T) {
 		time.Sleep(1 * time.Millisecond)
 	}
 
-	assert.EqualError(testTxnContext.errorReplies[0].err, "500 Internal Server Error")
+	assert.Regexp("500 Internal Server Error", testTxnContext.errorReplies[0].err)
 }
 
 func TestOnDeployContractMessageFailAddressLookup(t *testing.T) {
@@ -1200,7 +1200,7 @@ func TestOnDeployContractMessageFailAddressLookup(t *testing.T) {
 		time.Sleep(1 * time.Millisecond)
 	}
 
-	assert.EqualError(testTxnContext.errorReplies[0].err, "Error querying Addressbook")
+	assert.Regexp("Error querying Addressbook", testTxnContext.errorReplies[0].err)
 
 }
 
@@ -1222,7 +1222,7 @@ func TestOnDeployContractMessageFailHDWalletMissing(t *testing.T) {
 		time.Sleep(1 * time.Millisecond)
 	}
 
-	assert.EqualError(testTxnContext.errorReplies[0].err, "No HD Wallet Configuration")
+	assert.Regexp("No HD Wallet Configuration", testTxnContext.errorReplies[0].err)
 
 }
 
@@ -1245,7 +1245,7 @@ func TestOnDeployContractMessageFailHDWalletFail(t *testing.T) {
 		time.Sleep(1 * time.Millisecond)
 	}
 
-	assert.EqualError(testTxnContext.errorReplies[0].err, "HDWallet signing failed")
+	assert.Regexp("HDWallet signing failed", testTxnContext.errorReplies[0].err)
 
 }
 
@@ -1300,5 +1300,5 @@ func TestResolveAddressHDWalletFail(t *testing.T) {
 	}, &eth.RPCConf{}).(*txnProcessor)
 
 	_, err := txnProcessor.ResolveAddress("hd-testinst-testwallet-1234")
-	assert.EqualError(err, "No HD Wallet Configuration")
+	assert.Regexp("No HD Wallet Configuration", err)
 }

--- a/internal/utils/httprequester_test.go
+++ b/internal/utils/httprequester_test.go
@@ -30,7 +30,7 @@ func TestHTTPRequesterDoRequestBadURL(t *testing.T) {
 	hr := NewHTTPRequester("unit test", &HTTPRequesterConf{})
 
 	_, err := hr.DoRequest("GET", "! a URL", nil)
-	assert.EqualError(err, "Error querying unit test")
+	assert.Regexp("Error querying unit test", err)
 }
 
 func TestHTTPRequesterDoRequestBadPayload(t *testing.T) {
@@ -41,7 +41,7 @@ func TestHTTPRequesterDoRequestBadPayload(t *testing.T) {
 	bodyMap := make(map[string]interface{})
 	bodyMap["unserializable"] = map[bool]interface{}{true: "JSON does not like this"}
 	_, err := hr.DoRequest("GET", "http://localhost", bodyMap)
-	assert.Regexp("Failed to serialize request payload", err.Error())
+	assert.Regexp("Failed to serialize request payload", err)
 }
 
 func TestHTTPRequesterErrorStatus(t *testing.T) {
@@ -58,7 +58,7 @@ func TestHTTPRequesterErrorStatus(t *testing.T) {
 	hr := NewHTTPRequester("unit test", &HTTPRequesterConf{})
 
 	_, err := hr.DoRequest("GET", server.URL, nil)
-	assert.EqualError(err, "unit test returned [500]: poof")
+	assert.Regexp("unit test returned \\[500\\]: poof", err)
 }
 
 func TestHTTPRequesterUnknownError(t *testing.T) {
@@ -75,7 +75,7 @@ func TestHTTPRequesterUnknownError(t *testing.T) {
 	hr := NewHTTPRequester("unit test", &HTTPRequesterConf{})
 
 	_, err := hr.DoRequest("GET", server.URL, nil)
-	assert.EqualError(err, "Error querying unit test")
+	assert.Regexp("Error querying unit test", err)
 }
 
 func TestHTTPRequesterPOSTSuccess(t *testing.T) {
@@ -155,7 +155,7 @@ func TestHTTPRequesterBadResponse(t *testing.T) {
 	hr := NewHTTPRequester("unit test", &HTTPRequesterConf{})
 
 	_, err := hr.DoRequest("GET", server.URL, nil)
-	assert.EqualError(err, "Could not process unit test [200] response")
+	assert.Regexp("Could not process unit test \\[200\\] response", err)
 }
 
 func TestHTTPRequesterGetResponseStringVariants(t *testing.T) {
@@ -170,10 +170,10 @@ func TestHTTPRequesterGetResponseStringVariants(t *testing.T) {
 	}
 
 	_, err := hr.GetResponseString(body, "non-existent", true)
-	assert.EqualError(err, "'non-existent' missing in unit test response")
+	assert.Regexp("'non-existent' missing in unit test response", err)
 
 	_, err = hr.GetResponseString(body, "not-a-string", true)
-	assert.EqualError(err, "'not-a-string' not a string in unit test response")
+	assert.Regexp("'not-a-string' not a string in unit test response", err)
 
 	str, err := hr.GetResponseString(body, "a-string", true)
 	assert.NoError(err)
@@ -184,6 +184,6 @@ func TestHTTPRequesterGetResponseStringVariants(t *testing.T) {
 	assert.Equal("", str)
 
 	_, err = hr.GetResponseString(body, "nil-value", false)
-	assert.EqualError(err, "'nil-value' empty (or null) in unit test response")
+	assert.Regexp("'nil-value' empty \\(or null\\) in unit test response", err)
 
 }

--- a/internal/utils/payloadutils_test.go
+++ b/internal/utils/payloadutils_test.go
@@ -65,7 +65,7 @@ func TestYAMLorJSONPayloadTooBig(t *testing.T) {
 	req := httptest.NewRequest("POST", "/anything", bytes.NewReader(bigBytes))
 
 	_, err := YAMLorJSONPayload(req)
-	assert.EqualError(err, "Message exceeds maximum allowable size")
+	assert.Regexp("Message exceeds maximum allowable size", err)
 }
 
 func TestYAMLorJSONPayloadReadError(t *testing.T) {

--- a/internal/ws/wsserver_test.go
+++ b/internal/ws/wsserver_test.go
@@ -81,7 +81,7 @@ func TestConnectSendReceiveCycle(t *testing.T) {
 	})
 
 	err = <-r
-	assert.EqualError(err, "Error received from WebSocket client: Panic!")
+	assert.Regexp("Error received from WebSocket client: Panic!", err)
 
 	w.Close()
 


### PR DESCRIPTION
- Allocate unique integers to every error
- Include in the errors when printed in the logs
- Wherever possible retain the code-free error in the return on REST `"error": "message goes here"` JSON responses
- Add a separate `"code": "FFEC100049"` on all rest responses
- Add a separate `"errorCode": "FFEC100049"` on replies in the receipt store