### PR TITLE
Reduce default fetch below 1MB in the case of a small circuit breaker upper bound

### DIFF
--- a/internal/kafka/kafkacommon_test.go
+++ b/internal/kafka/kafkacommon_test.go
@@ -376,3 +376,18 @@ func TestConsumerErrorLoopLogsAndContinues(t *testing.T) {
 	k.signals <- os.Interrupt
 	wg.Wait()
 }
+
+func TestGetFetchDefault(t *testing.T) {
+	assert := assert.New(t)
+
+	assert.Equal(int32(1024*1024), getFetchDefault())
+	err := InitCircuitBreaker(&CircuitBreakerConf{
+		Enabled:    true,
+		UpperBound: 1024 * 1024 * 6,
+	})
+	assert.NoError(err)
+	assert.Equal(int32(314572), getFetchDefault())
+
+	singletonCircuitBreaker = nil
+
+}


### PR DESCRIPTION
After considering  in https://github.com/hyperledger/firefly-ethconnect/pull/175#pullrequestreview-813026469a bit of detail, I came to the conclusion this is a step forwards. Given that:
- Sarama only allows querying the HWM that has most recently been obtained via a fetch
- Configuring the producer to actually consume every message, in order to continually fetch, would be very inefficient 

This isn't perfect, as it still requires the consumer to be actively consuming for the circuit breaker to function.
However, in practice I believe it will protect from overflowing the buffer in the common case as even if the chain were stalled, batches of messages will be being consumed and returned with a timeout error periodically.