### PR TITLE
Fix post-merge build issue related to error codes

### DIFF
--- a/internal/contractgateway/smartcontractgw.go
+++ b/internal/contractgateway/smartcontractgw.go
@@ -526,7 +526,7 @@ func (g *smartContractGW) addSub(res http.ResponseWriter, req *http.Request, par
 	log.Infof("--> %s %s", req.Method, req.URL)
 
 	if g.sm == nil {
-		g.gatewayErrReply(res, req, errors.New(errEventSupportMissing), 405)
+		g.gatewayErrReply(res, req, errEventSupportMissing, 405)
 		return
 	}
 


### PR DESCRIPTION
See failure here https://github.com/hyperledger/firefly-ethconnect/runs/4301810830?check_suite_focus=true

Combination of #178 post-merge with #177

```
# github.com/hyperledger/firefly-ethconnect/internal/contractgateway
internal/contractgateway/smartcontractgw.go:529:31: undefined: "github.com/hyperledger/firefly-ethconnect/internal/errors".New
make: *** [Makefile:43: deps] Error 2
```