### PR TITLE
Fixing contract deployment and example doc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN make clean all
 
 FROM debian:buster-slim
 WORKDIR /ethconnect
+COPY --from=builder /usr/bin/solc /usr/bin/solc
 COPY --from=builder /ethconnect/ethconnect .
 COPY --from=builder /ethconnect/ethbinding.so .
 COPY --from=builder /ethconnect/start.sh .

--- a/README.md
+++ b/README.md
@@ -95,22 +95,24 @@ params:
   - 12345
 gas: 1000000
 solidity: |-
-  pragma solidity >=0.4.22 <0.6.0;
+  // SPDX-License-Identifier: UNLICENSED
+
+  pragma solidity >=0.7;
 
   contract simplestorage {
-     uint public storedData;
+    uint public storedData;
 
-     function simplestorage(uint initVal) public {
-        storedData = initVal;
-     }
+    constructor(uint initVal) public {
+      storedData = initVal;
+    }
 
-     function set(uint x) public {
-        storedData = x;
-     }
+    function set(uint x) public {
+      storedData = x;
+    }
 
-     function get() public view returns (uint retVal) {
-        return storedData;
-     }
+    function get() public view returns (uint retVal) {
+      return storedData;
+    }
   }
 ```
 


### PR DESCRIPTION
When trying to run the sample contract deployment payload, I was getting this error:

```
ERROR <-- POST /hook [500]: exec: "solc": executable file not found in $PATH
```

I've added the `solc` executable to the output image and then updated the `DeployContract` sample payload to be compatible with the newer version of `solc`. 