### PR TITLE
Including Latest CA Certs in Docker Image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,9 @@ COPY --from=builder /ethconnect/start.sh .
 
 # get the latest CA certs and symlink the ethconnect binary
 RUN apt-get update \
-    && apt-get install -y ca-certificates \
+    && apt-get install -y --no-install-recommends ca-certificates \
+    && update-ca-certificates \
+    && rm -rf /var/lib/apt/lists/* \
     && ln -s /ethconnect/ethconnect /usr/bin/ethconnect
 
 RUN mkdir abis

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,11 @@ WORKDIR /ethconnect
 COPY --from=builder /ethconnect/ethconnect .
 COPY --from=builder /ethconnect/ethbinding.so .
 COPY --from=builder /ethconnect/start.sh .
-RUN ln -s /ethconnect/ethconnect /usr/bin/ethconnect
+
+# get the latest CA certs and symlink the ethconnect binary
+RUN apt-get update \
+    && apt-get install -y ca-certificates \
+    && ln -s /ethconnect/ethconnect /usr/bin/ethconnect
+
 RUN mkdir abis
 ENTRYPOINT [ "./start.sh" ]


### PR DESCRIPTION
When trying to have Ethconnect connect to a remote Geth node secured via HTTPS we noticed we were getting invalid cert errors:
```
x509: certificate signed by unknown authority
```

In the process of testing to confirm this fixes this issue.