### PR TITLE
Fixing Graceful Shutdown for Container Image

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -1,12 +1,15 @@
 #!/bin/sh
 
+args=""
 if [ "$#" -eq 0 ]; then
     if [ -n "${ETHCONNECT_CONFIGFILE}" ]; then
-        ethconnect server
+        args="server"
     else
         echo "ETHCONNECT_CONFIGFILE unset, and no commandline parameters. Running with default standalone configuration"
-        ethconnect rest -U http://127.0.0.1:8080 -I ./abis -r http://127.0.0.1:8545 -E ./events
+        args="rest -U http://127.0.0.1:8080 -I ./abis -r http://127.0.0.1:8545 -E ./events"
     fi
 else
-    ethconnect $@
+    args="$@"
 fi
+
+exec ethconnect $args


### PR DESCRIPTION
Noticed in a K8s environment when testing https://github.com/hyperledger/firefly-helm-charts/pull/12 that ethconnect was very slow to shut down. Likely bc its not receiving the sigterm: https://hynek.me/articles/docker-signals/

> If you run your application from a shell script the regular way, your shell spawns your application in a new process and you 
> won’t receive signals from Docker.
>
> What you need to do is to tell your shell to replace itself with your application. For that exact purpose, shells have the exec > command (the similarity to the exec form before is not an accident: exec syscall).