### PR TITLE
Allow passing an array of ABI methods that might emit an event, when creating a sub

### DIFF
--- a/internal/contractregistry/contractstore.go
+++ b/internal/contractregistry/contractstore.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/go-openapi/spec"
 	lru "github.com/hashicorp/golang-lru"
+	ethbinding "github.com/kaleido-io/ethbinding/pkg"
 	log "github.com/sirupsen/logrus"
 
 	ethconnecterrors "github.com/hyperledger/firefly-ethconnect/internal/errors"
@@ -123,11 +124,13 @@ const (
 	RemoteGateway abiType = iota
 	RemoteInstance
 	LocalABI
+	InlineABI
 )
 
 type ABILocation struct {
-	ABIType abiType `json:"type"`
-	Name    string  `json:"name"`
+	ABIType abiType                  `json:"type"`
+	Name    string                   `json:"name"`
+	Inline  ethbinding.ABIMarshaling `json:"inline"`
 }
 
 func IsRemote(msg messages.CommonHeaders) bool {

--- a/internal/contractregistry/contractstore.go
+++ b/internal/contractregistry/contractstore.go
@@ -29,7 +29,6 @@ import (
 
 	"github.com/go-openapi/spec"
 	lru "github.com/hashicorp/golang-lru"
-	ethbinding "github.com/kaleido-io/ethbinding/pkg"
 	log "github.com/sirupsen/logrus"
 
 	ethconnecterrors "github.com/hyperledger/firefly-ethconnect/internal/errors"
@@ -124,13 +123,11 @@ const (
 	RemoteGateway abiType = iota
 	RemoteInstance
 	LocalABI
-	InlineABI
 )
 
 type ABILocation struct {
-	ABIType abiType                  `json:"type"`
-	Name    string                   `json:"name"`
-	Inline  ethbinding.ABIMarshaling `json:"inline"`
+	ABIType abiType `json:"type"`
+	Name    string  `json:"name"`
 }
 
 func IsRemote(msg messages.CommonHeaders) bool {

--- a/internal/events/logprocessor.go
+++ b/internal/events/logprocessor.go
@@ -37,6 +37,7 @@ type logEntry struct {
 	Timestamp        uint64                 `json:"timestamp,omitempty"`
 	InputMethod      string                 `json:"inputMethod,omitempty"`
 	InputArgs        map[string]interface{} `json:"inputArgs,omitempty"`
+	InputSigner      string                 `json:"inputSigner,omitempty"`
 }
 
 type eventData struct {

--- a/internal/events/logprocessor.go
+++ b/internal/events/logprocessor.go
@@ -52,6 +52,7 @@ type eventData struct {
 	Timestamp        string                 `json:"timestamp,omitempty"`
 	InputMethod      string                 `json:"inputMethod,omitempty"`
 	InputArgs        map[string]interface{} `json:"inputArgs,omitempty"`
+	InputSigner      string                 `json:"inputSigner,omitempty"`
 	// Used for callback handling
 	batchComplete func(*eventData)
 }
@@ -130,6 +131,7 @@ func (lp *logProcessor) processLogEntry(subInfo string, entry *logEntry, idx int
 		LogIndex:         strconv.Itoa(idx),
 		InputMethod:      entry.InputMethod,
 		InputArgs:        entry.InputArgs,
+		InputSigner:      entry.InputSigner,
 		batchComplete:    lp.batchComplete,
 	}
 	if lp.stream.spec.Timestamps {

--- a/internal/events/submanager.go
+++ b/internal/events/submanager.go
@@ -159,7 +159,13 @@ func (s *subscriptionMGR) setInitialBlock(i *SubscriptionInfo, initialBlock stri
 
 // AddSubscription adds a new subscription
 func (s *subscriptionMGR) AddSubscription(ctx context.Context, addr *ethbinding.Address, abi *contractregistry.ABILocation, event *ethbinding.ABIElementMarshaling, streamID, initialBlock, name string) (*SubscriptionInfo, error) {
-	return s.addSubscriptionCommon(ctx, abi, &SubscriptionCreateDTO{
+	var abiRef *ABIRefOrInline
+	if abi != nil {
+		abiRef = &ABIRefOrInline{
+			ABILocation: *abi,
+		}
+	}
+	return s.addSubscriptionCommon(ctx, abiRef, &SubscriptionCreateDTO{
 		Address:   addr,
 		Name:      name,
 		Event:     event,
@@ -169,17 +175,16 @@ func (s *subscriptionMGR) AddSubscription(ctx context.Context, addr *ethbinding.
 }
 
 func (s *subscriptionMGR) AddSubscriptionDirect(ctx context.Context, newSub *SubscriptionCreateDTO) (*SubscriptionInfo, error) {
-	var abiLocation *contractregistry.ABILocation
+	var abiLocation *ABIRefOrInline
 	if newSub.Methods != nil {
-		abiLocation = &contractregistry.ABILocation{
-			ABIType: contractregistry.InlineABI,
-			Inline:  newSub.Methods,
+		abiLocation = &ABIRefOrInline{
+			Inline: newSub.Methods,
 		}
 	}
 	return s.addSubscriptionCommon(ctx, abiLocation, newSub)
 }
 
-func (s *subscriptionMGR) addSubscriptionCommon(ctx context.Context, abi *contractregistry.ABILocation, newSub *SubscriptionCreateDTO) (*SubscriptionInfo, error) {
+func (s *subscriptionMGR) addSubscriptionCommon(ctx context.Context, abi *ABIRefOrInline, newSub *SubscriptionCreateDTO) (*SubscriptionInfo, error) {
 	i := &SubscriptionInfo{
 		Name: newSub.Name,
 		TimeSorted: messages.TimeSorted{

--- a/internal/events/submanager.go
+++ b/internal/events/submanager.go
@@ -169,7 +169,14 @@ func (s *subscriptionMGR) AddSubscription(ctx context.Context, addr *ethbinding.
 }
 
 func (s *subscriptionMGR) AddSubscriptionDirect(ctx context.Context, newSub *SubscriptionCreateDTO) (*SubscriptionInfo, error) {
-	return s.addSubscriptionCommon(ctx, nil, newSub)
+	var abiLocation *contractregistry.ABILocation
+	if newSub.Methods != nil {
+		abiLocation = &contractregistry.ABILocation{
+			ABIType: contractregistry.InlineABI,
+			Inline:  newSub.Methods,
+		}
+	}
+	return s.addSubscriptionCommon(ctx, abiLocation, newSub)
 }
 
 func (s *subscriptionMGR) addSubscriptionCommon(ctx context.Context, abi *contractregistry.ABILocation, newSub *SubscriptionCreateDTO) (*SubscriptionInfo, error) {

--- a/internal/events/submanager_test.go
+++ b/internal/events/submanager_test.go
@@ -25,7 +25,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hyperledger/firefly-ethconnect/internal/contractregistry"
 	"github.com/hyperledger/firefly-ethconnect/internal/kvstore"
 	"github.com/hyperledger/firefly-ethconnect/mocks/contractregistrymocks"
 	"github.com/hyperledger/firefly-ethconnect/mocks/ethmocks"
@@ -316,7 +315,7 @@ func TestStreamAndSubscriptionInlineMethodArray(t *testing.T) {
 	})
 	assert.NoError(err)
 
-	assert.Equal(contractregistry.InlineABI, sub.ABI.ABIType)
+	assert.NotNil(sub.ABI.Inline)
 	assert.Equal("doPing", sub.ABI.Inline[0].Name)
 
 	close(blockCall)

--- a/internal/events/subscription.go
+++ b/internal/events/subscription.go
@@ -285,6 +285,9 @@ func (s *subscription) getTransactionInputs(ctx context.Context, l *logEntry) {
 		log.Infof("%s: error querying transaction info", s.logName)
 		return
 	}
+	if info.From != nil {
+		l.InputSigner = info.From.String()
+	}
 	method, err := abi.MethodById(*info.Input)
 	if err != nil {
 		log.Infof("%s: could not find matching method", s.logName)

--- a/internal/events/subscription_test.go
+++ b/internal/events/subscription_test.go
@@ -377,9 +377,11 @@ func TestGetTransactionInputsLoadABIFail(t *testing.T) {
 
 	s := &subscription{
 		info: &SubscriptionInfo{
-			ABI: &contractregistry.ABILocation{
-				ABIType: contractregistry.LocalABI,
-				Name:    "abi1",
+			ABI: &ABIRefOrInline{
+				ABILocation: contractregistry.ABILocation{
+					ABIType: contractregistry.LocalABI,
+					Name:    "abi1",
+				},
 			},
 		},
 		rpc: rpc,
@@ -407,9 +409,11 @@ func TestGetTransactionInputsMissingABI(t *testing.T) {
 
 	s := &subscription{
 		info: &SubscriptionInfo{
-			ABI: &contractregistry.ABILocation{
-				ABIType: contractregistry.LocalABI,
-				Name:    "abi1",
+			ABI: &ABIRefOrInline{
+				ABILocation: contractregistry.ABILocation{
+					ABIType: contractregistry.LocalABI,
+					Name:    "abi1",
+				},
 			},
 		},
 		rpc: rpc,
@@ -441,9 +445,11 @@ func TestGetTransactionInputsTxnInfoFail(t *testing.T) {
 
 	s := &subscription{
 		info: &SubscriptionInfo{
-			ABI: &contractregistry.ABILocation{
-				ABIType: contractregistry.LocalABI,
-				Name:    "abi1",
+			ABI: &ABIRefOrInline{
+				ABILocation: contractregistry.ABILocation{
+					ABIType: contractregistry.LocalABI,
+					Name:    "abi1",
+				},
 			},
 		},
 		rpc: rpc,
@@ -481,9 +487,11 @@ func TestGetTransactionInputsBadMethod(t *testing.T) {
 
 	s := &subscription{
 		info: &SubscriptionInfo{
-			ABI: &contractregistry.ABILocation{
-				ABIType: contractregistry.LocalABI,
-				Name:    "abi1",
+			ABI: &ABIRefOrInline{
+				ABILocation: contractregistry.ABILocation{
+					ABIType: contractregistry.LocalABI,
+					Name:    "abi1",
+				},
 			},
 		},
 		rpc: rpc,
@@ -546,9 +554,11 @@ func TestGetTransactionInputsSuccess(t *testing.T) {
 
 	s := &subscription{
 		info: &SubscriptionInfo{
-			ABI: &contractregistry.ABILocation{
-				ABIType: contractregistry.LocalABI,
-				Name:    "abi1",
+			ABI: &ABIRefOrInline{
+				ABILocation: contractregistry.ABILocation{
+					ABIType: contractregistry.LocalABI,
+					Name:    "abi1",
+				},
 			},
 		},
 		rpc: rpc,
@@ -592,8 +602,7 @@ func TestGetTransactionInputsSuccessInline(t *testing.T) {
 
 	s := &subscription{
 		info: &SubscriptionInfo{
-			ABI: &contractregistry.ABILocation{
-				ABIType: contractregistry.InlineABI,
+			ABI: &ABIRefOrInline{
 				Inline: ethbinding.ABIMarshaling{
 					{
 						Type: "function",

--- a/internal/events/subscription_test.go
+++ b/internal/events/subscription_test.go
@@ -497,8 +497,10 @@ func TestGetTransactionInputsBadMethod(t *testing.T) {
 		rpc: rpc,
 		cr:  cr,
 	}
+	fromAddr := ethbind.API.HexToAddress("0x0123456789AbcdeF0123456789abCdef01234567")
 	l := logEntry{
 		TransactionHash: [32]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+		InputSigner:     fromAddr.String(),
 	}
 	lCopy := l
 
@@ -507,6 +509,7 @@ func TestGetTransactionInputsBadMethod(t *testing.T) {
 			res := args[1]
 			*(res.(*eth.TxnInfo)) = eth.TxnInfo{
 				Input: &ethbinding.HexBytes{},
+				From:  &fromAddr,
 			}
 		}).
 		Return(nil)


### PR DESCRIPTION
Two features in this PR related to the `inputs: true` feature on event streams:

### 1. Include `inputSigner` in the response

Return the ethereum address of the `from` that comes back in the `eth_getTransactionByHash` when we're doing the input decoding. This is needed by the FireFly tokens connectors, and currently they have to make an inefficient extra call.

### 2. Add a list of method ABI signatures when subscribing, to avoid need for ABI to be registered

When you are creating a subscription directly, on `POST` `/subscriptions` with an inline Event definition you might still want the inputs to be resolved (the stream has `inputs: true` set).

However, there's no tie between the subscription and an an ABI in the contract registry in this case, so we need a way for you to manually specify an array of all the possible methods that might emit the event you're interested in. Otherwise, there's no way for EthConnect to match the method signature extracted from the transaction, back to a particular method ABI, in order to know how to RLP decode the input data.

This PR propose very simple extension to #177, allowing you to post the payload example below.

`POST` `/subscriptions`
```js
{
  "name": "mysub",
  "stream": "df02bbdd-7038-462e-934d-9b5c7493fcbb",
  "fromBlock": "latest",
  "address": "0x10393D362bEfa1fe52e613801D72Da358C0d76c0",
  "event": {
    "name": "stuffHappened",
    "type": "event",
    "anonymous": false,
    "inputs": [
      {
        "indexed": true,
        "name": "from",
        "type": "address"
      },
      {
        "indexed": true,
        "name": "val1",
        "type": "int64"
      }
    ]
  },
  "methods": [
    {
      "type": "function",
      "name": "doStuff",
      "constant": false,
      "inputs": [
        {
          "name": "val1",
          "type": "int64"
        }
      ],
      "outputs": [],
      "payable": false,
      "stateMutability": "nonpayable"
    }
  ]
}
```