### PR TITLE
Protect misconfiguring catchupModeBlockGap < catchupModePageSize and fix catchup

### DIFF
--- a/internal/events/submanager.go
+++ b/internal/events/submanager.go
@@ -414,7 +414,7 @@ func (s *subscriptionMGR) loadCheckpoint(streamID string) (map[string]*big.Int, 
 func (s *subscriptionMGR) storeCheckpoint(streamID string, checkpoint map[string]*big.Int) error {
 	cpID := checkpointIDPrefix + streamID
 	b, _ := json.MarshalIndent(&checkpoint, "", "  ")
-	log.Debugf("Storing checkpoint %s: %s", cpID, string(b))
+	log.Tracef("Storing checkpoint %s: %s", cpID, string(b))
 	return s.db.Put(cpID, b)
 }
 

--- a/internal/events/submanager.go
+++ b/internal/events/submanager.go
@@ -122,6 +122,10 @@ func NewSubscriptionManager(conf *SubscriptionManagerConf, rpc eth.RPCClient, cr
 	if conf.CatchupModePageSize <= 0 {
 		conf.CatchupModePageSize = defaultCatchupModePageSize
 	}
+	if conf.CatchupModeBlockGap < conf.CatchupModePageSize {
+		log.Warnf("catchupModeBlockGap=%d must be >= catchupModePageSize=%d - setting to %d", conf.CatchupModeBlockGap, conf.CatchupModePageSize, conf.CatchupModePageSize)
+		conf.CatchupModeBlockGap = conf.CatchupModePageSize
+	}
 	return sm
 }
 

--- a/internal/events/submanager_test.go
+++ b/internal/events/submanager_test.go
@@ -79,6 +79,17 @@ func newTestSubscriptionManager() *subscriptionMGR {
 	return sm
 }
 
+func TestNestSubscriptionManagerBlockGapValidation(t *testing.T) {
+	smconf := &SubscriptionManagerConf{
+		CatchupModeBlockGap: 10,
+		CatchupModePageSize: 1000,
+	}
+	rpc := &ethmocks.RPCClient{}
+	cr := &contractregistrymocks.ContractStore{}
+	sm := NewSubscriptionManager(smconf, rpc, cr, newMockWebSocket()).(*subscriptionMGR)
+	assert.Equal(t, int64(1000), sm.conf.CatchupModeBlockGap)
+}
+
 func TestCobraInitSubscriptionManager(t *testing.T) {
 	assert := assert.New(t)
 	cmd := cobra.Command{}


### PR DESCRIPTION
See #198 for the 🤕 behavior you can get if we don't protect against this.

The logic here has an implicit assumption of this rule, so that when we read a page it's never going to extend past the `blockNumber` of the header of the chain at the point we query.

Otherwise, we think:
- Gap to head 1234 is > 250 - so we're in catchup
- Read 5000 (page size) - cool we've read 5000 blocks ... but actually there were only 1234 to read!!!
- ok, now we're not in catchup any more - start reading from where we left off - but that's now skipped a whole bunch of blocks.

https://github.com/hyperledger/firefly-ethconnect/blob/f6c7fe5499d111a25d2301b84efdb8a13db988e2/internal/events/subscription.go#L223-L248