### PR TITLE
Don't store highestNonce=0 if eth_getTransationCount fails (and solc 8 support)

### DIFF
--- a/internal/eth/txn_test.go
+++ b/internal/eth/txn_test.go
@@ -59,8 +59,8 @@ func (r *testRPCClient) CallContext(ctx context.Context, result interface{}, met
 }
 
 const (
-	simpleStorage = "pragma solidity >=0.4.22 <=0.7;\n\ncontract simplestorage {\nuint public storedData;\n\nconstructor(uint initVal) public {\nstoredData = initVal;\n}\n\nfunction set(uint x) public {\nstoredData = x;\n}\n\nfunction get() public view returns (uint retVal) {\nreturn storedData;\n}\n}"
-	twoContracts  = "pragma solidity >=0.4.22 <=0.7;\n\ncontract contract1 {function f1() public pure returns (uint retVal) {\nreturn 1;\n}\n}\n\ncontract contract2 {function f2() public pure returns (uint retVal) {\nreturn 2;\n}\n}"
+	simpleStorage = "pragma solidity >=0.4.22 <=0.8;\n\ncontract simplestorage {\nuint public storedData;\n\nconstructor(uint initVal) public {\nstoredData = initVal;\n}\n\nfunction set(uint x) public {\nstoredData = x;\n}\n\nfunction get() public view returns (uint retVal) {\nreturn storedData;\n}\n}"
+	twoContracts  = "pragma solidity >=0.4.22 <=0.8;\n\ncontract contract1 {function f1() public pure returns (uint retVal) {\nreturn 1;\n}\n}\n\ncontract contract2 {function f2() public pure returns (uint retVal) {\nreturn 2;\n}\n}"
 )
 
 func TestNewContractDeployTxnSimpleStorage(t *testing.T) {
@@ -446,7 +446,7 @@ func testComplexParam(t *testing.T, solidityType string, val interface{}, expect
 	assert := assert.New(t)
 
 	var msg messages.DeployContract
-	msg.Solidity = "pragma solidity >=0.4.22 <=0.7; contract test {constructor(" + solidityType + " p1) public {}}"
+	msg.Solidity = "pragma solidity >=0.4.22 <=0.8; contract test {constructor(" + solidityType + " p1) public {}}"
 	msg.Parameters = []interface{}{val}
 	msg.From = "0xAA983AD2a0e0eD8ac639277F37be42F2A5d2618c"
 	msg.Nonce = "123"
@@ -565,8 +565,8 @@ func TestSolidityArrayOfByteArraysParamConversion(t *testing.T) {
 	// These types are weird, as they are arrays of arrays of bytes.
 	// We do not support HEX strings for these, but the docs explicitly discourage their
 	// use in favour of bytes8 etc.
-	testComplexParam(t, "byte[8] memory", []string{"fe", "ed", "be", "ef"}, "")
-	testComplexParam(t, "byte[] memory", []string{"fe", "ed", "be", "ef"}, "")
+	// Solidity 8 removed byte[] and you have to use byte1[]
+	testComplexParam(t, "bytes1[8] memory", []string{"fe", "ed", "be", "ef"}, "")
 	testComplexParam(t, "bytes1[] memory", []string{"fe", "ed", "be", "ef"}, "")
 }
 

--- a/internal/events/submanager_test.go
+++ b/internal/events/submanager_test.go
@@ -255,6 +255,7 @@ func TestStreamAndSubscriptionErrors(t *testing.T) {
 	blockCall := make(chan struct{})
 	rpc := &ethmocks.RPCClient{}
 	rpc.On("CallContext", mock.Anything, mock.Anything, mock.Anything).Run(func(args mock.Arguments) { <-blockCall }).Return(nil)
+	rpc.On("CallContext", mock.Anything, mock.Anything, "eth_newFilter", mock.Anything).Return(nil).Maybe()
 	sm.rpc = rpc
 
 	sm.db, _ = kvstore.NewLDBKeyValueStore(path.Join(dir, "db"))

--- a/internal/rest/webhookskafka_test.go
+++ b/internal/rest/webhookskafka_test.go
@@ -387,7 +387,7 @@ func TestWebhookHandlerYAMLDeployContract(t *testing.T) {
 		"  type: DeployContract\n" +
 		"from: '0x4b098809E68C88e26442491c57866b7D4852216c'\n" +
 		"solidity: |-\n" +
-		"  pragma solidity >=0.4.22 <=0.7;\n" +
+		"  pragma solidity >=0.4.22 <=0.8;\n" +
 		"  \n" +
 		"  contract simplestorage {\n" +
 		"    uint public storedData;\n" +

--- a/internal/tx/txnprocessor_test.go
+++ b/internal/tx/txnprocessor_test.go
@@ -79,7 +79,7 @@ const testFromAddr = "0x83dBC8e329b38cBA0Fc4ed99b1Ce9c2a390ABdC1"
 
 var goodDeployTxnJSON = "{" +
 	"  \"headers\":{\"type\": \"DeployContract\"}," +
-	"  \"solidity\":\"pragma solidity >=0.4.22 <=0.7; contract t {constructor() public {}}\"," +
+	"  \"solidity\":\"pragma solidity >=0.4.22 <=0.8; contract t {constructor() public {}}\"," +
 	"  \"from\":\"" + testFromAddr + "\"," +
 	"  \"nonce\":\"123\"," +
 	"  \"gas\":\"123\"" +
@@ -87,7 +87,7 @@ var goodDeployTxnJSON = "{" +
 
 var goodHDWalletDeployTxnJSON = "{" +
 	"  \"headers\":{\"type\": \"DeployContract\"}," +
-	"  \"solidity\":\"pragma solidity >=0.4.22 <=0.7; contract t {constructor() public {}}\"," +
+	"  \"solidity\":\"pragma solidity >=0.4.22 <=0.8; contract t {constructor() public {}}\"," +
 	"  \"from\":\"hd-testinst-testwallet-1234\"," +
 	"  \"nonce\":\"123\"," +
 	"  \"gas\":\"123\"" +
@@ -108,7 +108,7 @@ var goodSendTxnJSONWithoutGas = "{" +
 
 var goodDeployTxnPrivateJSON = "{" +
 	"  \"headers\":{\"type\": \"DeployContract\"}," +
-	"  \"solidity\":\"pragma solidity >=0.4.22 <=0.7; contract t {constructor() public {}}\"," +
+	"  \"solidity\":\"pragma solidity >=0.4.22 <=0.8; contract t {constructor() public {}}\"," +
 	"  \"from\":\"" + testFromAddr + "\"," +
 	"  \"nonce\":\"123\"," +
 	"  \"gas\":\"123\"," +

--- a/test/simpleevents.sol
+++ b/test/simpleevents.sol
@@ -1,4 +1,4 @@
- pragma solidity >=0.5.2 <=0.7;
+ pragma solidity >=0.5.2 <=0.8;
 /**
   * @title Simple Storage with events
   * @dev Read and write values to the chain


### PR DESCRIPTION
This snippet below shows that if we get an error on `eth_getTransactionCount`, we seem to go on and perform later processing as if the nonce is zero.

Reviewing the code I found this is because of this is not backed out on error:
https://github.com/hyperledger/firefly-ethconnect/blob/f67b8400a5458e8f73870f75eee067b77cce199f/internal/tx/txnprocessor.go#L260

And in the case EthConnect is fully managing nonces (for example for high concurrency parallel submission), when we come back round for the next time round rather than calling `eth_getTranscationAccount` again,  we will read the `highestNonce` as `0`:
https://github.com/hyperledger/firefly-ethconnect/blob/f67b8400a5458e8f73870f75eee067b77cce199f/internal/tx/txnprocessor.go#L265-L271

My proposed fix, is to defer assignment back to the map until the success return path of the function.

Made two other unrelated changes:
1) Support for compiling EthConnect with `solc` 8 in your path (previously only worked up to `solc` 7)
   - This involved removing the type checking for `byte[]` which is no longer applicable
2) Performing explicit returns in the error paths of `addInflightWrapper` for readability

```
[2022-02-16T12:29:50.935Z]  INFO Received reply message. requestId='0257b3e8-3754-4ec9-70b0-58cf8d200001' reqOffset='' type='Error': eth_getTransactionCount returned: Post "http://localhost:8545": dial tcp 127.0.0.1:8545: connect: connection refused
[2022-02-16T12:29:50.935Z]  INFO 0257b3e8-3754-4ec9-70b0-58cf8d200001: Inserted receipt into receipt store
[2022-02-16T12:29:50.935Z]  INFO Received reply message. requestId='54b6f18a-5c7d-474f-4ac9-cd208403e88a' reqOffset='' type='Error': Call failed: Post "http://10.10.80.27:8545": dial tcp 10.10.80.27:8545: connect: connection refused
[2022-02-16T12:29:50.935Z]  INFO 54b6f18a-5c7d-474f-4ac9-cd208403e88a: Inserted receipt into receipt store
[2022-02-16T12:29:50.935Z]  INFO Received reply message. requestId='6346500f-0308-428d-5a56-10f0a9b50cce' reqOffset='' type='Error': eth_getTransactionCount returned: Post "http://localhost:8545": dial tcp 127.0.0.1:8545: connect: connection refused
[2022-02-16T12:29:50.935Z]  INFO 6346500f-0308-428d-5a56-10f0a9b50cce: Inserted receipt into receipt store
[2022-02-16T12:29:50.935Z]  INFO Received reply message. requestId='ceff65fd-0517-4d5e-410f-c393afe54dfe' reqOffset='' type='Error': Call failed: Post "http://10.10.80.27:8545": dial tcp 10.10.80.27:8545: connect: connection refused
[2022-02-16T12:29:50.935Z]  INFO ceff65fd-0517-4d5e-410f-c393afe54dfe: Inserted receipt into receipt store
[2022-02-16T12:29:50.935Z]  INFO Received reply message. requestId='17e31eae-90bf-4a84-4604-fe87478f0634' reqOffset='' type='Error': eth_getTransactionCount returned: Post "http://localhost:8545": dial tcp 127.0.0.1:8545: connect: connection refused
[2022-02-16T12:29:50.936Z]  INFO 17e31eae-90bf-4a84-4604-fe87478f0634: Inserted receipt into receipt store
[2022-02-16T12:29:50.950Z]  INFO Using cached RPC connection for signing
[2022-02-16T12:29:50.950Z]  INFO In-flight 11361389 added. nonce=2 addr=0xd9db2b11609fdbff838c15b2bcb00dfc03fb6f31 before=1 (node=false)
[2022-02-16T12:29:51.391Z]  WARN TX: Failed to send: nonce too low [0.46s]
```