### PR TITLE
Remove newline between fields in log

### DIFF
--- a/internal/contractgateway/rest2eth.go
+++ b/internal/contractgateway/rest2eth.go
@@ -727,7 +727,7 @@ func (r *rest2eth) lookupTransaction(res http.ResponseWriter, req *http.Request,
 func (r *rest2eth) restAsyncReply(res http.ResponseWriter, req *http.Request, asyncResponse messages.WebhookReply) {
 	resBytes, _ := json.Marshal(asyncResponse)
 	status := 202 // accepted
-	log.Infof("<-- %s %s [%d]:\n%s", req.Method, req.URL, status, string(resBytes))
+	log.Infof("<-- %s %s [%d]: %s", req.Method, req.URL, status, string(resBytes))
 	log.Debugf("<-- %s", resBytes)
 	res.Header().Set("Content-Type", "application/json")
 	res.WriteHeader(status)


### PR DESCRIPTION
This PR removes a newline in a log that outputs the request ID and offset. Logging on the same line makes it easier to search for an offset or a request ID in the logs to correlate the lifecycle of a request (when received, when received on the consumer side, final response sent etc.)

Signed-off-by: Vinod Damle <vinod.damle@kaleido.io>