### PR TITLE
Inflight reset

### DIFF
--- a/internal/events/eventstream.go
+++ b/internal/events/eventstream.go
@@ -243,69 +243,108 @@ func (a *eventStream) postUpdateStream() {
 	a.batchCond.L.Unlock()
 }
 
+func (a *eventStream) checkUpdate(newSpec *StreamInfo) (updatedSpec *StreamInfo, err error) {
+
+	// setUpdated marks that there is a change, and creates a copied object
+	specCopy := *a.spec
+	setUpdated := func() *StreamInfo {
+		if updatedSpec == nil {
+			updatedSpec = &specCopy
+		}
+		return updatedSpec
+	}
+
+	if newSpec.Type != "" && newSpec.Type != specCopy.Type {
+		return nil, errors.Errorf(errors.EventStreamsCannotUpdateType)
+	}
+	if specCopy.Type == "webhook" && newSpec.Webhook != nil {
+		if newSpec.Webhook.RequestTimeoutSec != 0 && newSpec.Webhook.RequestTimeoutSec != specCopy.Webhook.RequestTimeoutSec {
+			setUpdated().Webhook.RequestTimeoutSec = newSpec.Webhook.RequestTimeoutSec
+		}
+		if newSpec.Webhook.TLSkipHostVerify != specCopy.Webhook.TLSkipHostVerify {
+			setUpdated().Webhook.TLSkipHostVerify = newSpec.Webhook.TLSkipHostVerify
+		}
+		if newSpec.Webhook.URL != "" && newSpec.Webhook.URL != specCopy.Webhook.URL {
+			if _, err = url.Parse(newSpec.Webhook.URL); err != nil {
+				return nil, errors.Errorf(errors.EventStreamsWebhookInvalidURL)
+			}
+			setUpdated().Webhook.URL = newSpec.Webhook.URL
+		}
+		for k, v := range newSpec.Webhook.Headers {
+			if specCopy.Webhook.Headers == nil || specCopy.Webhook.Headers[k] != v {
+				setUpdated().Webhook.Headers = newSpec.Webhook.Headers
+				break
+			}
+		}
+	}
+	if specCopy.Type == "websocket" && newSpec.WebSocket != nil {
+		if newSpec.WebSocket.Topic != specCopy.WebSocket.Topic {
+			setUpdated().WebSocket.Topic = newSpec.WebSocket.Topic
+		}
+		if newSpec.WebSocket.DistributionMode != specCopy.WebSocket.DistributionMode {
+			setUpdated().WebSocket.DistributionMode = newSpec.WebSocket.DistributionMode
+		}
+		// Validate if we changed it
+		if updatedSpec != nil {
+			if err := validateWebSocket(newSpec.WebSocket); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	if specCopy.BatchSize != newSpec.BatchSize && newSpec.BatchSize != 0 && newSpec.BatchSize < MaxBatchSize {
+		setUpdated().BatchSize = newSpec.BatchSize
+	}
+	if specCopy.BatchTimeoutMS != newSpec.BatchTimeoutMS && newSpec.BatchTimeoutMS != 0 {
+		setUpdated().BatchTimeoutMS = newSpec.BatchTimeoutMS
+	}
+	if specCopy.BlockedRetryDelaySec != newSpec.BlockedRetryDelaySec && newSpec.BlockedRetryDelaySec != 0 {
+		setUpdated().BlockedRetryDelaySec = newSpec.BlockedRetryDelaySec
+	}
+	if newSpec.ErrorHandling != "" && newSpec.ErrorHandling != specCopy.ErrorHandling {
+		if strings.ToLower(newSpec.ErrorHandling) == ErrorHandlingBlock {
+			setUpdated().ErrorHandling = ErrorHandlingBlock
+		} else {
+			setUpdated().ErrorHandling = ErrorHandlingSkip
+		}
+	}
+	if newSpec.Name != "" && specCopy.Name != newSpec.Name {
+		setUpdated().Name = newSpec.Name
+	}
+	if specCopy.Timestamps != newSpec.Timestamps {
+		setUpdated().Timestamps = newSpec.Timestamps
+	}
+	if specCopy.Inputs != newSpec.Inputs {
+		setUpdated().Inputs = newSpec.Inputs
+	}
+
+	// Return a non-nil object ONLY if there's a change
+	return updatedSpec, nil
+}
+
 // update modifies an existing eventStream
 func (a *eventStream) update(newSpec *StreamInfo) (spec *StreamInfo, err error) {
 	log.Infof("%s: Update event stream", a.spec.ID)
+	updatedSpec, err := a.checkUpdate(newSpec)
+	if err != nil {
+		return nil, err
+	}
+	if updatedSpec == nil {
+		log.Infof("%s: No change", a.spec.ID)
+		return a.spec, nil
+	}
+
 	// set a flag to indicate updateInProgress
 	// For any go routines that are Wait() ing on the eventListener, wake them up
 	if err := a.preUpdateStream(); err != nil {
 		return nil, err
 	}
+	a.spec = updatedSpec
 	// wait for the poked goroutines to finish up
 	<-a.eventPollerDone
 	<-a.batchProcessorDone
 	<-a.batchDispatcherDone
 	defer a.postUpdateStream()
-
-	if newSpec.Type != "" && newSpec.Type != a.spec.Type {
-		return nil, errors.Errorf(errors.EventStreamsCannotUpdateType)
-	}
-	if a.spec.Type == "webhook" && newSpec.Webhook != nil {
-		if newSpec.Webhook.URL == "" {
-			return nil, errors.Errorf(errors.EventStreamsWebhookNoURL)
-		}
-		if _, err = url.Parse(newSpec.Webhook.URL); err != nil {
-			return nil, errors.Errorf(errors.EventStreamsWebhookInvalidURL)
-		}
-		if newSpec.Webhook.RequestTimeoutSec == 0 {
-			newSpec.Webhook.RequestTimeoutSec = 120
-		}
-		a.spec.Webhook.URL = newSpec.Webhook.URL
-		a.spec.Webhook.RequestTimeoutSec = newSpec.Webhook.RequestTimeoutSec
-		a.spec.Webhook.TLSkipHostVerify = newSpec.Webhook.TLSkipHostVerify
-		a.spec.Webhook.Headers = newSpec.Webhook.Headers
-	}
-	if a.spec.Type == "websocket" && newSpec.WebSocket != nil {
-		a.spec.WebSocket.Topic = newSpec.WebSocket.Topic
-		if err := validateWebSocket(newSpec.WebSocket); err != nil {
-			return nil, err
-		}
-		a.spec.WebSocket.DistributionMode = newSpec.WebSocket.DistributionMode
-	}
-
-	if a.spec.BatchSize != newSpec.BatchSize && newSpec.BatchSize != 0 && newSpec.BatchSize < MaxBatchSize {
-		a.spec.BatchSize = newSpec.BatchSize
-	}
-	if a.spec.BatchTimeoutMS != newSpec.BatchTimeoutMS && newSpec.BatchTimeoutMS != 0 {
-		a.spec.BatchTimeoutMS = newSpec.BatchTimeoutMS
-	}
-	if a.spec.BlockedRetryDelaySec != newSpec.BlockedRetryDelaySec && newSpec.BlockedRetryDelaySec != 0 {
-		a.spec.BlockedRetryDelaySec = newSpec.BlockedRetryDelaySec
-	}
-	if strings.ToLower(newSpec.ErrorHandling) == ErrorHandlingBlock {
-		a.spec.ErrorHandling = ErrorHandlingBlock
-	} else {
-		a.spec.ErrorHandling = ErrorHandlingSkip
-	}
-	if newSpec.Name != "" && a.spec.Name != newSpec.Name {
-		a.spec.Name = newSpec.Name
-	}
-	if a.spec.Timestamps != newSpec.Timestamps {
-		a.spec.Timestamps = newSpec.Timestamps
-	}
-	if a.spec.Inputs != newSpec.Inputs {
-		a.spec.Inputs = newSpec.Inputs
-	}
 	return a.spec, nil
 }
 

--- a/internal/events/submanager_test.go
+++ b/internal/events/submanager_test.go
@@ -254,8 +254,8 @@ func TestStreamAndSubscriptionErrors(t *testing.T) {
 
 	blockCall := make(chan struct{})
 	rpc := &ethmocks.RPCClient{}
-	rpc.On("CallContext", mock.Anything, mock.Anything, mock.Anything).Run(func(args mock.Arguments) { <-blockCall }).Return(nil)
 	rpc.On("CallContext", mock.Anything, mock.Anything, "eth_newFilter", mock.Anything).Return(nil).Maybe()
+	rpc.On("CallContext", mock.Anything, mock.Anything, mock.Anything).Run(func(args mock.Arguments) { <-blockCall }).Return(nil)
 	sm.rpc = rpc
 
 	sm.db, _ = kvstore.NewLDBKeyValueStore(path.Join(dir, "db"))

--- a/internal/events/websockets.go
+++ b/internal/events/websockets.go
@@ -86,6 +86,6 @@ func (w *webSocketAction) attemptBatch(batchNumber, attempt uint64, events []*ev
 	}
 
 	// Pass back any exception from the client
-	log.Infof("Attempt batch %d complete. ok=%t", batchNumber, err == nil)
+	log.Infof("WebSocket event batch %d complete (len=%d). err=%v", batchNumber, len(events), err)
 	return err
 }


### PR DESCRIPTION
Currently every time FireFly starts, it resets the EthConnect stream with a `PATCH` in order to apply any changes.
I observed a problem where a stream did not continue sending events after such an event.

I was able to produce a problem running two simple `curl` loops, where one stream stalled:

### 1. Sending messages with confirm

```sh
while [ 1 ]; do echo POSTING $(date); curl -s -X POST -d '{"data":[{"value":"test"}]}' -H "Content-type: application/json" 'localhost:5000/api/v1/namespaces/default/messages/broadcast?confirm' | jq; sleep 1; done
```

### 2. Resetting the stream

```sh
while [ 1 ]; do echo RESET $(date); curl -s -X PATCH -d @/tmp/ev.json  -H "Content-type: application/json" 0.0.0.0:5102/eventstreams/es-9f5df9e3-563e-4f11-7750-5d147ccf0231; sleep 1; done
```

There was not anything in the logs that really showed why the stream had stopped distributing data, and nothing in a `goroutine` dump. So I spent some time on code inspection, and made the changes in this PR.

- Reset the `InFlight` count to zero on update
    - This seemed to be a straight bug, and after fixing this I was not able to reproduce the stall
- Add better logging in case it happens again
    - Particularly per-polling loop debug when `InFlight > 0`
- Do not restart a stream if a `PATCH` does not result in any change