### PR TITLE
Intermittent failure in TestConfirmationsRemoveEvent

### DIFF
--- a/internal/events/block_confirmations_test.go
+++ b/internal/events/block_confirmations_test.go
@@ -595,6 +595,7 @@ func TestConfirmationsRemoveEvent(t *testing.T) {
 		event: event,
 	})
 
+	changeCount := 0
 	rpc.On("CallContext", mock.Anything, mock.Anything, "eth_newBlockFilter").Run(func(args mock.Arguments) {
 		args[1].(*hexutil.Big).ToInt().SetString("1977", 10)
 	}).Return(nil).Maybe()
@@ -602,8 +603,11 @@ func TestConfirmationsRemoveEvent(t *testing.T) {
 		return i.ToInt().Int64() == int64(1977)
 	})).Run(func(args mock.Arguments) {
 		*(args[1].(*[]*ethbinding.Hash)) = []*ethbinding.Hash{}
-		bcm.cancelFunc()
-	}).Return(nil).Maybe()
+		changeCount++
+		if changeCount > 1 {
+			bcm.cancelFunc()
+		}
+	}).Return(nil)
 	rpc.On("CallContext", mock.Anything, mock.Anything, "eth_getBlockByNumber", mock.MatchedBy(func(i hexutil.Uint64) bool {
 		return uint64(i) == 1002
 	}), false).Run(func(args mock.Arguments) {

--- a/internal/events/block_confirmations_test.go
+++ b/internal/events/block_confirmations_test.go
@@ -564,6 +564,11 @@ func TestConfirmationsListenerStopStream(t *testing.T) {
 	})).Run(func(args mock.Arguments) {
 		*(args[1].(*[]*ethbinding.Hash)) = []*ethbinding.Hash{}
 	}).Return(nil)
+	rpc.On("CallContext", mock.Anything, mock.Anything, "eth_getBlockByNumber", mock.MatchedBy(func(i hexutil.Uint64) bool {
+		return uint64(i) == 1002
+	}), false).Run(func(args mock.Arguments) {
+		*(args[1].(**blockInfo)) = nil
+	}).Return(nil).Maybe()
 
 	bcm.start()
 

--- a/internal/events/submanager_test.go
+++ b/internal/events/submanager_test.go
@@ -132,7 +132,7 @@ func TestInitLevelDBFail(t *testing.T) {
 	sm.Close(true)
 }
 
-func TestActionAndSubscriptionLifecyle(t *testing.T) {
+func TestActionAndSubscriptionLifecycle(t *testing.T) {
 	assert := assert.New(t)
 	dir := tempdir(t)
 	subscriptionName := "testSub"
@@ -143,6 +143,7 @@ func TestActionAndSubscriptionLifecyle(t *testing.T) {
 	rpc.On("CallContext", mock.Anything, mock.Anything, "eth_newFilter", mock.Anything).Return(nil)
 	rpc.On("CallContext", mock.Anything, mock.Anything, "eth_getFilterLogs", mock.Anything).Return(nil)
 	rpc.On("CallContext", mock.Anything, mock.Anything, "eth_uninstallFilter", mock.Anything).Return(nil)
+	rpc.On("CallContext", mock.Anything, mock.Anything, "eth_uninstallFilter", mock.Anything).Return(nil).Maybe()
 
 	sm := newTestSubscriptionManager()
 	sm.rpc = rpc
@@ -229,6 +230,7 @@ func TestActionChildCleanup(t *testing.T) {
 	rpc := &ethmocks.RPCClient{}
 	rpc.On("CallContext", mock.Anything, mock.Anything, mock.Anything).Run(func(args mock.Arguments) { <-blockCall }).Return(nil)
 	rpc.On("CallContext", mock.Anything, mock.Anything, "eth_newFilter", mock.Anything).Return(nil)
+	rpc.On("CallContext", mock.Anything, mock.Anything, "eth_uninstallFilter", mock.Anything).Return(nil).Maybe()
 	sm.rpc = rpc
 
 	sm.db, _ = kvstore.NewLDBKeyValueStore(path.Join(dir, "db"))
@@ -264,6 +266,7 @@ func TestStreamAndSubscriptionErrors(t *testing.T) {
 	rpc.On("CallContext", mock.Anything, mock.Anything, "eth_newFilter", mock.Anything).Return(nil).Maybe()
 	rpc.On("CallContext", mock.Anything, mock.Anything, "eth_getFilterLogs", mock.Anything).Return(nil).Maybe()
 	rpc.On("CallContext", mock.Anything, mock.Anything, mock.Anything).Run(func(args mock.Arguments) { <-blockCall }).Return(nil)
+	rpc.On("CallContext", mock.Anything, mock.Anything, "eth_uninstallFilter", mock.Anything).Return(nil).Maybe()
 	sm.rpc = rpc
 
 	sm.db, _ = kvstore.NewLDBKeyValueStore(path.Join(dir, "db"))


### PR DESCRIPTION
```
time="2022-04-25T13:56:09-04:00" level=info msg="Added pending event TX:0x531e219d98d81dc9f9a14811ac537479f5d77a74bdba47629bfbebe2d7663ce7|BLOCK:/0x0e32d749a86cfaf551d528b5b121cea456f980a39e5b8136eb8e85dbc744a542|INDEX:|LOG:" job=blockConfirmationManager
time="2022-04-25T13:56:09-04:00" level=info msg="Created block filter: 0x7b9" job=blockConfirmationManager
time="2022-04-25T13:56:09-04:00" level=info msg="Block 1002 unavailable walking chain event=TX:0x531e219d98d81dc9f9a14811ac537479f5d77a74bdba47629bfbebe2d7663ce7|BLOCK:/0x0e32d749a86cfaf551d528b5b121cea456f980a39e5b8136eb8e85dbc744a542|INDEX:|LOG:" job=blockConfirmationManager
time="2022-04-25T13:56:09-04:00" level=debug msg="Block confirmation listener stopping" job=blockConfirmationManager
--- FAIL: TestConfirmationsRemoveEvent (0.00s)
    block_confirmations_test.go:616: 
        	Error Trace:	block_confirmations_test.go:616
        	Error:      	Should be empty, but was map[TX:0x531e219d98d81dc9f9a14811ac537479f5d77a74bdba47629bfbebe2d7663ce7|BLOCK:/0x0e32d749a86cfaf551d528b5b121cea456f980a39e5b8136eb8e85dbc744a542|INDEX:|LOG::0x1400038c1e0]
        	Test:       	TestConfirmationsRemoveEvent
```