### PR TITLE
Add fly-id based idempotency for LevelDB (as implemented for MongoDB)

### DIFF
--- a/internal/contractgateway/smartcontractgw.go
+++ b/internal/contractgateway/smartcontractgw.go
@@ -54,7 +54,7 @@ import (
 
 var (
 	maxFormParsingMemory   int64 = 32 << 20 // 32 MB
-	errEventSupportMissing       = errors.Errorf(errors.EventSupportNotConfiugred)
+	errEventSupportMissing       = errors.Errorf(errors.EventSupportNotConfigured)
 )
 
 // remoteContractInfo is the ABI raw data back out of the REST API gateway with bytecode

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -511,8 +511,8 @@ var (
 	// FFCBlockNotAvailable is returned when a receipt is not found
 	FFCBlockNotAvailable = e(100218, "Block not available")
 
-	// ReceiptStoreLevelDBKeyNotUnique idempotency check failed on request ID
-	ReceiptStoreLevelDBKeyNotUnique = e(100219, "Request ID is not unique")
+	// ReceiptStoreKeyNotUnique non-unique request ID
+	ReceiptStoreKeyNotUnique = e(100219, "Request ID is not unique")
 )
 
 type EthconnectError interface {

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -511,7 +511,7 @@ var (
 	// FFCBlockNotAvailable is returned when a receipt is not found
 	FFCBlockNotAvailable = e(100218, "Block not available")
 
-	// ReceiptStoreLevelDBKeyNotUnique idepotency check failed on request ID
+	// ReceiptStoreLevelDBKeyNotUnique idempotency check failed on request ID
 	ReceiptStoreLevelDBKeyNotUnique = e(100219, "Request ID is not unique")
 )
 

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -485,8 +485,8 @@ var (
 	// CircuitBreakerTripped is returned when the Kafka circuit breaker has deemed it unsafe to produce more messages
 	CircuitBreakerTripped = e(100206, "Unable to send Kafka message as the gap of %d messages between consumer and producer is too large. Estimated at %.2fKb")
 
-	// EventSupportNotConfiugred is returned when event support is not configured
-	EventSupportNotConfiugred = e(100207, "Event support is not configured on this gateway")
+	// EventSupportNotConfigured is returned when event support is not configured
+	EventSupportNotConfigured = e(100207, "Event support is not configured on this gateway")
 
 	// FFCBadVersion is returned when an FFCAPI request has a bad version header
 	FFCBadVersion = e(100208, "Bad FFCAPI Version '%s': %s")
@@ -510,6 +510,9 @@ var (
 	FFCRequestTypeNotImplemented = e(100217, "FFCAPI request '%s' not currently supported")
 	// FFCBlockNotAvailable is returned when a receipt is not found
 	FFCBlockNotAvailable = e(100218, "Block not available")
+
+	// ReceiptStoreLevelDBKeyNotUnique idepotency check failed on request ID
+	ReceiptStoreLevelDBKeyNotUnique = e(100219, "Request ID is not unique")
 )
 
 type EthconnectError interface {

--- a/internal/events/submanager_test.go
+++ b/internal/events/submanager_test.go
@@ -230,6 +230,7 @@ func TestActionChildCleanup(t *testing.T) {
 	rpc := &ethmocks.RPCClient{}
 	rpc.On("CallContext", mock.Anything, mock.Anything, mock.Anything).Run(func(args mock.Arguments) { <-blockCall }).Return(nil)
 	rpc.On("CallContext", mock.Anything, mock.Anything, "eth_newFilter", mock.Anything).Return(nil)
+	rpc.On("CallContext", mock.Anything, mock.Anything, "eth_getFilterLogs", mock.Anything).Return(nil).Maybe()
 	rpc.On("CallContext", mock.Anything, mock.Anything, "eth_uninstallFilter", mock.Anything).Return(nil).Maybe()
 	sm.rpc = rpc
 

--- a/internal/rest/leveldbreceipts.go
+++ b/internal/rest/leveldbreceipts.go
@@ -72,7 +72,7 @@ func (l *levelDBReceipts) AddReceipt(requestID string, receipt *map[string]inter
 		if overwrite {
 			lookupKey = string(existingKey)
 		} else {
-			return errors.Errorf(errors.ReceiptStoreLevelDBKeyNotUnique)
+			return errors.Errorf(errors.ReceiptStoreKeyNotUnique)
 		}
 	}
 

--- a/internal/rest/leveldbreceipts.go
+++ b/internal/rest/leveldbreceipts.go
@@ -56,24 +56,28 @@ func newLevelDBReceipts(conf *LevelDBReceiptStoreConf) (*levelDBReceipts, error)
 
 // AddReceipt processes an individual reply message, and contains all errors
 // To account for any transitory failures writing to mongoDB, it retries adding receipt with a backoff
-func (l *levelDBReceipts) AddReceipt(requestID string, receipt *map[string]interface{}) (err error) {
+func (l *levelDBReceipts) AddReceipt(requestID string, receipt *map[string]interface{}, overwrite bool) (err error) {
 	// insert an entry with a composite key to track the insertion order
 	l.entropyLock.Lock()
 	newID := ulid.MustNew(ulid.Timestamp(time.Now()), l.idEntropy)
 	// We check for key uniqueness in this lock, to provide an idempotent interface
-	_, err = l.store.Get(requestID)
+	existingKey, err := l.store.Get(requestID)
 	l.entropyLock.Unlock()
 
+	lookupKey := fmt.Sprintf("z%s", newID)
 	if err == kvstore.ErrorNotFound {
 		// This is what we expect
 		err = nil
 	} else if err == nil {
-		return errors.Errorf(errors.ReceiptStoreLevelDBKeyNotUnique)
+		if overwrite {
+			lookupKey = string(existingKey)
+		} else {
+			return errors.Errorf(errors.ReceiptStoreLevelDBKeyNotUnique)
+		}
 	}
 
 	// add "z" prefix so these entries come after the lookup entries
 	// because for iteration we start from last backwards
-	lookupKey := fmt.Sprintf("z%s", newID)
 	b, _ := json.MarshalIndent(receipt, "", "  ")
 	err = l.store.Put(lookupKey, b)
 

--- a/internal/rest/memreceipts_test.go
+++ b/internal/rest/memreceipts_test.go
@@ -31,8 +31,9 @@ func TestMemReceiptsWrapping(t *testing.T) {
 
 	for i := 0; i < 100; i++ {
 		receipt := make(map[string]interface{})
-		receipt["key"] = fmt.Sprintf("receipt_%d", i)
-		r.AddReceipt("key", &receipt, false)
+		reqID := fmt.Sprintf("receipt_%d", i)
+		receipt["_id"] = reqID
+		r.AddReceipt(reqID, &receipt, false)
 	}
 
 	assert.Equal(50, r.receipts.Len())
@@ -40,7 +41,7 @@ func TestMemReceiptsWrapping(t *testing.T) {
 	for i := 0; i < 50; i++ {
 		expectedKey := fmt.Sprintf("receipt_%d", 100-i-1)
 		val := *currItem.Value.(*map[string]interface{})
-		assert.Equal(val["key"], expectedKey)
+		assert.Equal(val["_id"], expectedKey)
 		currItem = currItem.Next()
 	}
 }

--- a/internal/rest/memreceipts_test.go
+++ b/internal/rest/memreceipts_test.go
@@ -32,7 +32,7 @@ func TestMemReceiptsWrapping(t *testing.T) {
 	for i := 0; i < 100; i++ {
 		receipt := make(map[string]interface{})
 		receipt["key"] = fmt.Sprintf("receipt_%d", i)
-		r.AddReceipt("key", &receipt)
+		r.AddReceipt("key", &receipt, false)
 	}
 
 	assert.Equal(50, r.receipts.Len())

--- a/internal/rest/mongoreceipts.go
+++ b/internal/rest/mongoreceipts.go
@@ -76,8 +76,13 @@ func (m *mongoReceipts) connect() (err error) {
 
 // AddReceipt processes an individual reply message, and contains all errors
 // To account for any transitory failures writing to mongoDB, it retries adding receipt with a backoff
-func (m *mongoReceipts) AddReceipt(requestID string, receipt *map[string]interface{}) (err error) {
-	return m.collection.Insert(*receipt)
+func (m *mongoReceipts) AddReceipt(requestID string, receipt *map[string]interface{}, overwrite bool) (err error) {
+	if overwrite {
+		query := m.collection.Find(bson.M{"_id": requestID})
+		return m.collection.Upsert(query, *receipt)
+	} else {
+		return m.collection.Insert(*receipt)
+	}
 }
 
 // GetReceipts Returns recent receipts with skip & limit

--- a/internal/rest/mongoreceipts_test.go
+++ b/internal/rest/mongoreceipts_test.go
@@ -58,6 +58,11 @@ func (m *mockCollection) Insert(payloads ...interface{}) error {
 	return m.insertErr
 }
 
+func (m *mockCollection) Upsert(query interface{}, payload interface{}) error {
+	m.inserted = payload.(map[string]interface{})
+	return m.insertErr
+}
+
 func (m *mockCollection) Create(info *mgo.CollectionInfo) error {
 	m.collInfo = info
 	return m.collErr
@@ -181,7 +186,7 @@ func TestMongoReceiptsConnectIdxErr(t *testing.T) {
 	assert.Regexp("Unable to create index: pop", err)
 }
 
-func TestMongoReceiptsAddReceiptOK(t *testing.T) {
+func TestMongoReceiptsInsertReceiptOK(t *testing.T) {
 	assert := assert.New(t)
 
 	mgoMock := &mockMongo{}
@@ -192,7 +197,22 @@ func TestMongoReceiptsAddReceiptOK(t *testing.T) {
 
 	r.connect()
 	receipt := make(map[string]interface{})
-	err := r.AddReceipt("key", &receipt)
+	err := r.AddReceipt("key", &receipt, false)
+	assert.NoError(err)
+}
+
+func TestMongoReceiptsUpsertReceiptOK(t *testing.T) {
+	assert := assert.New(t)
+
+	mgoMock := &mockMongo{}
+	r := &mongoReceipts{
+		conf: &MongoDBReceiptStoreConf{},
+		mgo:  mgoMock,
+	}
+
+	r.connect()
+	receipt := make(map[string]interface{})
+	err := r.AddReceipt("key", &receipt, true)
 	assert.NoError(err)
 }
 
@@ -208,7 +228,7 @@ func TestMongoReceiptsAddReceiptFailed(t *testing.T) {
 
 	r.connect()
 	receipt := make(map[string]interface{})
-	err := r.AddReceipt("key", &receipt)
+	err := r.AddReceipt("key", &receipt, false)
 	assert.Regexp("pop", err)
 }
 

--- a/internal/rest/mongwrapper.go
+++ b/internal/rest/mongwrapper.go
@@ -35,6 +35,7 @@ type MongoDatabase interface {
 // MongoCollection is the subset of mgo that we use, allowing stubbing
 type MongoCollection interface {
 	Insert(...interface{}) error
+	Upsert(query interface{}, doc interface{}) error
 	Create(info *mgo.CollectionInfo) error
 	EnsureIndex(index mgo.Index) error
 	Find(query interface{}) MongoQuery
@@ -71,6 +72,11 @@ func (m *collWrapper) EnsureIndex(index mgo.Index) error {
 
 func (m *collWrapper) Find(query interface{}) MongoQuery {
 	return m.coll.Find(query)
+}
+
+func (m *collWrapper) Upsert(query interface{}, doc interface{}) error {
+	_, err := m.coll.Upsert(query, doc)
+	return err
 }
 
 // MongoQuery is the subset of mgo that we use, allowing stubbing

--- a/internal/rest/receiptstore_test.go
+++ b/internal/rest/receiptstore_test.go
@@ -48,7 +48,7 @@ func (m *mockReceiptErrs) GetReceipt(requestID string) (*map[string]interface{},
 	return m.getReceiptVal, m.getReceiptErr
 }
 
-func (m *mockReceiptErrs) AddReceipt(requestID string, receipt *map[string]interface{}) error {
+func (m *mockReceiptErrs) AddReceipt(requestID string, receipt *map[string]interface{}, overwrite bool) error {
 	m.addReceiptCalled = true
 	return m.addReceiptErr
 }
@@ -204,33 +204,6 @@ func TestReplyProcessorWithPeristenceErrorPanics(t *testing.T) {
 	})
 }
 
-func TestReplyProcessorWithPeristenceErrorDuplicateSwallows(t *testing.T) {
-	existing := map[string]interface{}{"some": "existing"}
-	mr := &mockReceiptErrs{
-		addReceiptErr: fmt.Errorf("pop"),
-		getReceiptErr: nil,
-		getReceiptVal: &existing,
-	}
-	r := newReceiptStore(&ReceiptStoreConf{
-		RetryTimeoutMS:      1,
-		RetryInitialDelayMS: 1,
-	}, mr, nil)
-
-	replyMsg := &messages.TransactionReceipt{}
-	replyMsg.Headers.MsgType = messages.MsgTypeTransactionSuccess
-	replyMsg.Headers.ID = utils.UUIDv4()
-	replyMsg.Headers.ReqID = utils.UUIDv4()
-	replyMsg.Headers.ReqOffset = "topic:1:2"
-	txHash := ethbind.API.HexToHash("0x02587104e9879911bea3d5bf6ccd7e1a6cb9a03145b8a1141804cebd6aa67c5c")
-	replyMsg.TransactionHash = &txHash
-	replyMsgBytes, _ := json.Marshal(&replyMsg)
-
-	r.processReply(replyMsgBytes)
-
-	assert.True(t, mr.addReceiptCalled)
-
-}
-
 func TestReplyProcessorWithErrorReply(t *testing.T) {
 	assert := assert.New(t)
 
@@ -348,11 +321,11 @@ func TestGetReplyOK(t *testing.T) {
 	fakeReply1 := make(map[string]interface{})
 	fakeReply1["_id"] = "ABCDEFG"
 	fakeReply1["field1"] = "value1"
-	p.AddReceipt("_id", &fakeReply1)
+	p.AddReceipt("ABCDEFG", &fakeReply1, true)
 	fakeReply2 := make(map[string]interface{})
 	fakeReply2["_id"] = "BCDEFG"
 	fakeReply2["field1"] = "value2"
-	p.AddReceipt("_id", &fakeReply2)
+	p.AddReceipt("BCDEFG", &fakeReply2, true)
 	status, respJSON, httpErr := testGETObject(ts, "/reply/ABCDEFG")
 	assert.NoError(httpErr)
 	assert.Equal(200, status)
@@ -369,7 +342,7 @@ func TestGetReplyBadData(t *testing.T) {
 	unserializable := make(map[interface{}]interface{})
 	unserializable[true] = "not for json"
 	fakeReply["badness"] = unserializable
-	p.AddReceipt("_id", &fakeReply)
+	p.AddReceipt("ABCDEFG", &fakeReply, true)
 	status, respJSON, httpErr := testGETObject(ts, "/reply/ABCDEFG")
 	assert.NoError(httpErr)
 	assert.Equal(500, status)
@@ -429,7 +402,7 @@ func TestGetRepliesDefaultLimit(t *testing.T) {
 	for i := 0; i < 20; i++ {
 		fakeReply := make(map[string]interface{})
 		fakeReply["_id"] = fmt.Sprintf("reply%d", i)
-		p.AddReceipt("_id", &fakeReply)
+		p.AddReceipt("_id", &fakeReply, true)
 	}
 
 	status, respArr, httpErr := testGETArray(ts, "/replies")
@@ -449,7 +422,7 @@ func TestGetRepliesCustomSkipLimit(t *testing.T) {
 	for i := 0; i < 20; i++ {
 		fakeReply := make(map[string]interface{})
 		fakeReply["_id"] = fmt.Sprintf("reply%d", i)
-		p.AddReceipt("_id", &fakeReply)
+		p.AddReceipt("_id", &fakeReply, true)
 	}
 
 	status, respArr, httpErr := testGETArray(ts, "/replies?skip=5&limit=20")
@@ -469,7 +442,7 @@ func TestGetRepliesCustomFiltersISO(t *testing.T) {
 	for i := 0; i < 20; i++ {
 		fakeReply := make(map[string]interface{})
 		fakeReply["_id"] = fmt.Sprintf("reply%d", i)
-		p.AddReceipt("_id", &fakeReply)
+		p.AddReceipt("_id", &fakeReply, true)
 	}
 
 	status, resObj, httpErr := testGETObject(ts, "/replies?from=abc&to=bcd&since=2019-01-01T00:00:00Z")
@@ -486,7 +459,7 @@ func TestGetRepliesCustomFiltersTS(t *testing.T) {
 	for i := 0; i < 20; i++ {
 		fakeReply := make(map[string]interface{})
 		fakeReply["_id"] = fmt.Sprintf("reply%d", i)
-		p.AddReceipt("_id", &fakeReply)
+		p.AddReceipt("_id", &fakeReply, true)
 	}
 
 	status, resObj, httpErr := testGETObject(ts, "/replies?from=abc&to=bcd&since=1580435959")
@@ -503,7 +476,7 @@ func TestGetRepliesBadSinceTS(t *testing.T) {
 	for i := 0; i < 20; i++ {
 		fakeReply := make(map[string]interface{})
 		fakeReply["_id"] = fmt.Sprintf("reply%d", i)
-		p.AddReceipt("_id", &fakeReply)
+		p.AddReceipt("_id", &fakeReply, true)
 	}
 
 	status, resObj, httpErr := testGETObject(ts, "/replies?from=abc&to=bcd&since=badness")

--- a/internal/rest/receiptstore_test.go
+++ b/internal/rest/receiptstore_test.go
@@ -565,3 +565,32 @@ func TestSendReplyBroadcast(t *testing.T) {
 
 	r.processReply(replyMsgBytes)
 }
+
+func TestReserveID(t *testing.T) {
+	assert := assert.New(t)
+	r, _ := newReceiptsTestStore(func(message interface{}) {
+		assert.NotNil(message)
+	})
+
+	release, err := r.reserveID("12345")
+	assert.NoError(err)
+
+	_, err = r.reserveID("12345")
+	assert.Regexp("FFEC100219", err)
+
+	release()
+
+	release, err = r.reserveID("12345")
+	assert.NoError(err)
+
+	release()
+}
+
+func TestReserveIDFail(t *testing.T) {
+	assert := assert.New(t)
+	r, ts := newReceiptsErrTestServer(fmt.Errorf("pop"))
+	defer ts.Close()
+
+	_, err := r.reserveID("12345")
+	assert.Regexp("pop", err)
+}

--- a/internal/rest/webhooks.go
+++ b/internal/rest/webhooks.go
@@ -190,15 +190,31 @@ func (w *webhooks) processMsg(ctx context.Context, msg map[string]interface{}, a
 		}
 	}
 
+	// We reserve the ID before we do the call to Kafka. This is as good as we
+	// can get for idempotence in this model - there is still a window where it's possible
+	// Kafka accepts the message, but we are terminated before we get an error back.
+	if ack && immediateReceipt {
+		release, err := w.receipts.reserveID(msgID)
+		if err != nil {
+			return nil, 500, err
+		}
+		defer release()
+	}
+
 	// Pass to the handler
 	log.Infof("Webhook accepted message. MsgID: %s Type: %s", msgID, msgType)
 	msgAck, status, err := w.handler.sendWebhookMsg(ctx, key, msgID, msg, ack)
 	if err != nil {
 		return nil, status, err
 	}
+
 	if ack && immediateReceipt {
-		w.receipts.writeAccepted(msgID, msgAck, msg)
+		err := w.receipts.writeAccepted(msgID, msgAck, msg)
+		if err != nil {
+			return nil, 500, err
+		}
 	}
+
 	return &messages.AsyncSentMsg{
 		Sent:    true,
 		Request: msgID,

--- a/internal/rest/webhooks.go
+++ b/internal/rest/webhooks.go
@@ -196,7 +196,7 @@ func (w *webhooks) processMsg(ctx context.Context, msg map[string]interface{}, a
 	if ack && immediateReceipt {
 		release, err := w.receipts.reserveID(msgID)
 		if err != nil {
-			return nil, 500, err
+			return nil, 409 /* conflict */, err
 		}
 		defer release()
 	}


### PR DESCRIPTION
The `fly-id` (/`kld-id`) query param for idempotent submission of transactions, using an external ID combined with `fly-acktype=receipt` (/`kld-acktype`), functions based on the DB requiring uniquness.

LevelDB doesn't have this as a first class construct, so we need to implement it at the ethconnect code layer.
 
Solving this e2e meant implementing an `overwrite` option through the stack, to pick between "keep trying to insert, with overwrite" functionality when storing the final reply, vs. "try inserting, and fail immediately" functionality when storing the initial `acktype=receipt`.

I also found an unrelated issue with the in-memory receipt store, where it was not retaining _any_ history by default when configured via YAML. A real pain for FireFly CLI based environments.