### PR TITLE
Updates for parallel processing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,47 +2,59 @@ module github.com/hyperledger/firefly-ethconnect
 
 require (
 	github.com/Masterminds/semver v1.5.0
-	github.com/Shopify/sarama v1.32.0
+	github.com/PuerkitoBio/purell v1.1.1 // indirect
+	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
+	github.com/Shopify/sarama v1.33.0
 	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751
 	github.com/bketelsen/crypt v0.0.4 // indirect
-	github.com/btcsuite/btcd/btcec/v2 v2.1.3 // indirect
+	github.com/btcsuite/btcd/btcec/v2 v2.2.0 // indirect
 	github.com/dsnet/compress v0.0.1 // indirect
 	github.com/ethereum/go-ethereum v1.10.17
+	github.com/fsnotify/fsnotify v1.5.4 // indirect
 	github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8
 	github.com/go-openapi/jsonreference v0.20.0
-	github.com/go-openapi/spec v0.20.5
+	github.com/go-openapi/spec v0.20.6
 	github.com/go-openapi/swag v0.21.1 // indirect
 	github.com/gorilla/websocket v1.5.0
+	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-uuid v1.0.3 // indirect
 	github.com/hashicorp/golang-lru v0.5.5-0.20210104140557-80c98217689d
-	github.com/hyperledger/firefly-common v0.1.2
+	github.com/hyperledger/firefly-common v0.1.4
 	github.com/icza/dyno v0.0.0-20210726202311-f1bafe5d9996
 	github.com/julienschmidt/httprouter v1.3.0
 	github.com/kaleido-io/ethbinding v0.0.0-20220405144420-999853435d9e
-	github.com/klauspost/compress v1.15.1 // indirect
+	github.com/klauspost/compress v1.15.4 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mattn/go-colorable v0.1.12 // indirect
 	github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d // indirect
 	github.com/mholt/archiver v3.1.1+incompatible
 	github.com/microcosm-cc/bluemonday v1.0.18 // indirect
+	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d
 	github.com/nwaples/rardecode v1.1.3 // indirect
 	github.com/oklog/ulid/v2 v2.0.2
+	github.com/pelletier/go-toml v1.9.5 // indirect
+	github.com/pelletier/go-toml/v2 v2.0.1 // indirect
 	github.com/shirou/gopsutil v3.21.11+incompatible // indirect
 	github.com/sirupsen/logrus v1.8.1
+	github.com/spf13/cast v1.5.0 // indirect
 	github.com/spf13/cobra v1.4.0
 	github.com/spf13/viper v1.11.0 // indirect
 	github.com/stretchr/testify v1.7.1
 	github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7
 	github.com/tidwall/gjson v1.14.1
 	github.com/tklauser/go-sysconf v0.3.10 // indirect
+	github.com/tklauser/numcpus v0.5.0 // indirect
 	github.com/ulikunitz/xz v0.5.10 // indirect
 	github.com/x-cray/logrus-prefixed-formatter v0.5.2
 	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 // indirect
 	github.com/yusufpapurcu/wmi v1.2.2 // indirect
-	golang.org/x/net v0.0.0-20220418201149-a630d4f3e7a2 // indirect
+	golang.org/x/crypto v0.0.0-20220513210258-46612604a0f9 // indirect
+	golang.org/x/net v0.0.0-20220516155154-20f960328961 // indirect
+	golang.org/x/sys v0.0.0-20220513210249-45d2b4557a2a // indirect
 	golang.org/x/term v0.0.0-20220411215600-e5f449aeb171 // indirect
 	gopkg.in/yaml.v2 v2.4.0
+	gopkg.in/yaml.v3 v3.0.0-20220512140231-539c8e751b99 // indirect
 )
 
 replace github.com/kaleido-io/ethbinding => ../ethbinding

--- a/go.sum
+++ b/go.sum
@@ -132,6 +132,8 @@ github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdko
 github.com/Shopify/logrus-bugsnag v0.0.0-20171204204709-577dee27f20d/go.mod h1:HI8ITrYtUY+O+ZhtlqUnD8+KwNPOyugEhfP9fdUIaEQ=
 github.com/Shopify/sarama v1.32.0 h1:P+RUjEaRU0GMMbYexGMDyrMkLhbbBVUVISDywi+IlFU=
 github.com/Shopify/sarama v1.32.0/go.mod h1:+EmJJKZWVT/faR9RcOxJerP+LId4iWdQPBGLy1Y1Njs=
+github.com/Shopify/sarama v1.33.0 h1:2K4mB9M4fo46sAM7t6QTsmSO8dLX1OqznLM7vn3OjZ8=
+github.com/Shopify/sarama v1.33.0/go.mod h1:lYO7LwEBkE0iAeTl94UfPSrDaavFzSFlmn+5isARATQ=
 github.com/Shopify/toxiproxy/v2 v2.3.0/go.mod h1:KvQTtB6RjCJY4zqNJn7C7JDFgsG5uoHYDirfUfpIm0c=
 github.com/StackExchange/wmi v0.0.0-20180116203802-5d049714c4a6/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
 github.com/StackExchange/wmi v1.2.1/go.mod h1:rcmrprowKIVzvc+NUiLncP2uuArMWLCbu9SBzvHz7e8=
@@ -223,7 +225,10 @@ github.com/btcsuite/btcd v0.22.0-beta/go.mod h1:9n5ntfhhHQBIhUvlhDvD3Qg6fRUj4jkN
 github.com/btcsuite/btcd/btcec/v2 v2.1.2/go.mod h1:ctjw4H1kknNJmRN4iP1R7bTQ+v3GJkZBd6mui8ZsAZE=
 github.com/btcsuite/btcd/btcec/v2 v2.1.3 h1:xM/n3yIhHAhHy04z4i43C8p4ehixJZMsnrVJkgl+MTE=
 github.com/btcsuite/btcd/btcec/v2 v2.1.3/go.mod h1:ctjw4H1kknNJmRN4iP1R7bTQ+v3GJkZBd6mui8ZsAZE=
+github.com/btcsuite/btcd/btcec/v2 v2.2.0 h1:fzn1qaOt32TuLjFlkzYSsBC35Q3KUjT1SwPxiMSCF5k=
+github.com/btcsuite/btcd/btcec/v2 v2.2.0/go.mod h1:U7MHm051Al6XmscBQ0BoNydpOTsFAn707034b5nY8zU=
 github.com/btcsuite/btcd/chaincfg/chainhash v1.0.0/go.mod h1:7SFka0XMvUgj3hfZtydOrQY2mwhPclbT2snogU7SQQc=
+github.com/btcsuite/btcd/chaincfg/chainhash v1.0.1/go.mod h1:7SFka0XMvUgj3hfZtydOrQY2mwhPclbT2snogU7SQQc=
 github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f/go.mod h1:TdznJufoqS23FtqVCzL0ZqgP5MqXbb4fg/WgDys70nA=
 github.com/btcsuite/btcutil v0.0.0-20190425235716-9e5f4b9a998d/go.mod h1:+5NJ2+qvTyV9exUAL/rxXi3DcLg2Ts+ymUAY5y4NvMg=
 github.com/btcsuite/btcutil v1.0.3-0.20201208143702-a53e38424cce/go.mod h1:0DVlHczLPewLcPGEIeUEzfOJhqGPQ0mJJRDBtD307+o=
@@ -474,10 +479,13 @@ github.com/form3tech-oss/jwt-go v3.2.5+incompatible/go.mod h1:pbq4aXjuKjdthFRnoD
 github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHquHwclZch5g=
 github.com/frankban/quicktest v1.11.3/go.mod h1:wRf/ReqHper53s+kmmSZizM8NamnL3IM0I9ntUbOk+k=
 github.com/frankban/quicktest v1.14.2/go.mod h1:mgiwOwqx65TmIk1wJ6Q7wvnVMocbUorkibMOrVTHZps=
+github.com/frankban/quicktest v1.14.3/go.mod h1:mgiwOwqx65TmIk1wJ6Q7wvnVMocbUorkibMOrVTHZps=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/fsnotify/fsnotify v1.5.1 h1:mZcQUHVQUQWoPXXtuf9yuEXKudkV2sx1E06UadKWpgI=
 github.com/fsnotify/fsnotify v1.5.1/go.mod h1:T3375wBYaZdLLcVNkcVbzGHY7f1l/uK5T5Ai1i3InKU=
+github.com/fsnotify/fsnotify v1.5.4 h1:jRbGcIw6P2Meqdwuo0H1p6JVLbL5DHKAKlYndzMwVZI=
+github.com/fsnotify/fsnotify v1.5.4/go.mod h1:OVB6XrOHzAwXMpEM7uPOzcehqUV2UqJxmVXmkdnm1bU=
 github.com/fsouza/fake-gcs-server v1.17.0/go.mod h1:D1rTE4YCyHFNa99oyJJ5HyclvN/0uQR+pM/VdlL83bw=
 github.com/fullsailor/pkcs7 v0.0.0-20190404230743-d7302db945fa/go.mod h1:KnogPXtdwXqoenmZCw6S+25EAm2MkxbG0deNDu4cbSA=
 github.com/gabriel-vasile/mimetype v1.3.1/go.mod h1:fA8fi6KUiG7MgQQ+mEWotXoEOvmxRtOJlERCzSmRvr8=
@@ -526,6 +534,8 @@ github.com/go-openapi/jsonreference v0.20.0/go.mod h1:Ag74Ico3lPc+zR+qjn4XBUmXym
 github.com/go-openapi/spec v0.19.3/go.mod h1:FpwSN1ksY1eteniUU7X0N/BgJ7a4WvBFVA8Lj9mJglo=
 github.com/go-openapi/spec v0.20.5 h1:skHa8av4VnAtJU5zyAUXrrdK/NDiVX8lchbG+BfcdrE=
 github.com/go-openapi/spec v0.20.5/go.mod h1:QbfOSIVt3/sac+a1wzmKbbcLXm5NdZnyBZYtCijp43o=
+github.com/go-openapi/spec v0.20.6 h1:ich1RQ3WDbfoeTqTAb+5EIxNmpKVJZWBNah9RAT0jIQ=
+github.com/go-openapi/spec v0.20.6/go.mod h1:2OpW+JddWPrpXSCIX8eOx7lZ5iyuWj3RYR6VaaBKcWA=
 github.com/go-openapi/swag v0.19.2/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh66Z9tfKk=
 github.com/go-openapi/swag v0.19.5/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh66Z9tfKk=
 github.com/go-openapi/swag v0.19.15/go.mod h1:QYRuS/SOXUCsnplDa677K7+DxSOj6IPNl/eQntq43wQ=
@@ -720,6 +730,7 @@ github.com/hashicorp/consul/sdk v0.1.1/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyN
 github.com/hashicorp/consul/sdk v0.8.0/go.mod h1:GBvyrGALthsZObzUGsfgHZQDXjg4lOjagTIwIR1vPms=
 github.com/hashicorp/errwrap v0.0.0-20141028054710-7554cd9344ce/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
+github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-bexpr v0.1.10/go.mod h1:oxlubA2vC/gFVfX1A6JGp7ls7uCDlfJn732ehYYg+g0=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
@@ -734,6 +745,7 @@ github.com/hashicorp/go-msgpack v0.5.3/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iP
 github.com/hashicorp/go-multierror v0.0.0-20161216184304-ed905158d874/go.mod h1:JMRHfdO9jKNzS/+BTlxCjKNQHg/jZAft8U7LloJvN7I=
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
 github.com/hashicorp/go-multierror v1.1.0/go.mod h1:spPvp8C1qA32ftKqdAHm4hHTbPw+vmowP0z+KUhOZdA=
+github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hashicorp/go-retryablehttp v0.5.3/go.mod h1:9B5zBasrRhHXnJnui7y6sL7es7NDiJgTc6Er0maI1Xs=
 github.com/hashicorp/go-rootcerts v1.0.0/go.mod h1:K6zTfqpRlCUIjkwsN4Z+hiSfzSTQa6eBIzfwKfwNnHU=
@@ -773,6 +785,8 @@ github.com/hyperledger/firefly-common v0.1.2-0.20220505012722-b17e8af423d7 h1:Ca
 github.com/hyperledger/firefly-common v0.1.2-0.20220505012722-b17e8af423d7/go.mod h1:ytB+404+Qg00wJKx602Yi/V6Spx9d0g65lZR9y5fzlo=
 github.com/hyperledger/firefly-common v0.1.2 h1:zwz7WAHrK5we8bku7FO1rGZSFY+N4sDO3fWrabsnL+E=
 github.com/hyperledger/firefly-common v0.1.2/go.mod h1:ytB+404+Qg00wJKx602Yi/V6Spx9d0g65lZR9y5fzlo=
+github.com/hyperledger/firefly-common v0.1.4 h1:wjZgYZohimKVlBxF3lZmrymVbHwgUIZQshQtE2AQvgQ=
+github.com/hyperledger/firefly-common v0.1.4/go.mod h1:ytB+404+Qg00wJKx602Yi/V6Spx9d0g65lZR9y5fzlo=
 github.com/iancoleman/strcase v0.2.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
@@ -910,8 +924,11 @@ github.com/klauspost/compress v1.13.1/go.mod h1:8dP1Hq4DHOhN9w426knH3Rhby4rFm6D8
 github.com/klauspost/compress v1.13.4/go.mod h1:8dP1Hq4DHOhN9w426knH3Rhby4rFm6D8eO+e+Dq5Gzg=
 github.com/klauspost/compress v1.13.6/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
 github.com/klauspost/compress v1.14.4/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
+github.com/klauspost/compress v1.15.0/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
 github.com/klauspost/compress v1.15.1 h1:y9FcTHGyrebwfP0ZZqFiaxTaiDnUrGkJkI+f583BL1A=
 github.com/klauspost/compress v1.15.1/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
+github.com/klauspost/compress v1.15.4 h1:1kn4/7MepF/CHmYub99/nNX8az0IJjfSOU/jbnTVfqQ=
+github.com/klauspost/compress v1.15.4/go.mod h1:PhcZ0MbTNciWF3rruxRgKxI5NkcHHrHUDtV4Yw2GlzU=
 github.com/klauspost/cpuid v0.0.0-20170728055534-ae7887de9fa5/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
 github.com/klauspost/cpuid v1.2.0/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
 github.com/klauspost/crc32 v0.0.0-20161016154125-cb6bfca970f6/go.mod h1:+ZoRqAPRLkC4NPOvfYeR5KNOrY6TD+/sAC3HXPZgDYg=
@@ -1020,6 +1037,8 @@ github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh
 github.com/mitchellh/mapstructure v1.4.1/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/mapstructure v1.4.3 h1:OVowDSCllw/YjdLkam3/sm7wEtOy59d8ndGgCcyj8cs=
 github.com/mitchellh/mapstructure v1.4.3/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
+github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
+github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/osext v0.0.0-20151018003038-5e2d6d41470f/go.mod h1:OkQIRizQZAeMln+1tSwduZz7+Af5oFlKirV/MSYes2A=
 github.com/mitchellh/pointerstructure v1.2.0/go.mod h1:BRAsLI5zgXmw97Lf6s25bs8ohIXc3tViBH44KcwB2g4=
 github.com/moby/locker v1.0.1/go.mod h1:S7SDdo5zpBK84bzzVlKr2V0hz+7x9hWbYC/kq7oQppc=
@@ -1125,8 +1144,12 @@ github.com/pelletier/go-toml v1.7.0/go.mod h1:vwGMzjaWMwyfHwgIBhI2YUM4fB6nL6lVAv
 github.com/pelletier/go-toml v1.8.1/go.mod h1:T2/BmBdy8dvIRq1a/8aqjN41wvWlN4lrapLU/GW4pbc=
 github.com/pelletier/go-toml v1.9.4 h1:tjENF6MfZAg8e4ZmZTeWaWiT2vXtsoO6+iuOjFhECwM=
 github.com/pelletier/go-toml v1.9.4/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
+github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3ve8=
+github.com/pelletier/go-toml v1.9.5/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/pelletier/go-toml/v2 v2.0.0-beta.8 h1:dy81yyLYJDwMTifq24Oi/IslOslRrDSb3jwDggjz3Z0=
 github.com/pelletier/go-toml/v2 v2.0.0-beta.8/go.mod h1:r9LEWfGN8R5k0VXJ+0BkIe7MYkRdwZOjgMj2KwnJFUo=
+github.com/pelletier/go-toml/v2 v2.0.1 h1:8e3L2cCQzLFi2CR4g7vGFuFxX7Jl1kKX8gW+iV0GUKU=
+github.com/pelletier/go-toml/v2 v2.0.1/go.mod h1:r9LEWfGN8R5k0VXJ+0BkIe7MYkRdwZOjgMj2KwnJFUo=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/peterh/liner v1.0.1-0.20180619022028-8c1271fcf47f/go.mod h1:xIteQHvHuaLYG9IFj6mSxM0fCKrs34IrEQUhOYuGPHc=
 github.com/peterh/liner v1.1.1-0.20190123174540-a2c9a5303de7/go.mod h1:CRroGNssyjTd/qIG2FyxByd2S8JEAZXBl4qUrZf8GS0=
@@ -1255,6 +1278,8 @@ github.com/spf13/afero v1.8.2/go.mod h1:CtAatgMJh6bJEIs48Ay/FOnkljP3WeGUG0MC1RfA
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cast v1.4.1 h1:s0hze+J0196ZfEMTs80N7UlFt0BDuQ7Q+JDnHiMWKdA=
 github.com/spf13/cast v1.4.1/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
+github.com/spf13/cast v1.5.0 h1:rj3WzYc11XZaIZMPKmwP96zkFEnnAmV8s6XbB2aY32w=
+github.com/spf13/cast v1.5.0/go.mod h1:SpXXQ5YoyJw6s3/6cMTQuxvgRl3PCJiyaX9p6b155UU=
 github.com/spf13/cobra v0.0.2-0.20171109065643-2da4a54c5cee/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
 github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
 github.com/spf13/cobra v1.0.0/go.mod h1:/6GTrnGXV9HjY+aR4k0oJ5tcvakLuG6EuKReYlHNrgE=
@@ -1316,6 +1341,8 @@ github.com/tklauser/go-sysconf v0.3.10/go.mod h1:C8XykCvCb+Gn0oNCWPIlcb0RuglQTYa
 github.com/tklauser/numcpus v0.2.2/go.mod h1:x3qojaO3uyYt0i56EW/VUYs7uBvdl2fkfZFu0T9wgjM=
 github.com/tklauser/numcpus v0.4.0 h1:E53Dm1HjH1/R2/aoCtXtPgzmElmn51aOkhCFSuZq//o=
 github.com/tklauser/numcpus v0.4.0/go.mod h1:1+UI3pD8NW14VMwdgJNJ1ESk2UnwhAnz5hMwiKKqXCQ=
+github.com/tklauser/numcpus v0.5.0 h1:ooe7gN0fg6myJ0EKoTAf5hebTZrH52px3New/D9iJ+A=
+github.com/tklauser/numcpus v0.5.0/go.mod h1:OGzpTxpcIMNGYQdit2BYL1pvk/dSOaJWjKoflh+RQjo=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
@@ -1349,7 +1376,9 @@ github.com/xanzy/go-gitlab v0.15.0/go.mod h1:8zdQa/ri1dfn8eS3Ir1SyfvOKlw7WBJ8DVT
 github.com/xdg-go/pbkdf2 v1.0.0/go.mod h1:jrpuAogTd400dnrH08LKmI/xc1MbPOebTwRqcT5RDeI=
 github.com/xdg-go/scram v1.0.2/go.mod h1:1WAq6h33pAW+iRreB34OORO2Nf7qel3VV3fjBj+hCSs=
 github.com/xdg-go/scram v1.1.0/go.mod h1:1WAq6h33pAW+iRreB34OORO2Nf7qel3VV3fjBj+hCSs=
+github.com/xdg-go/scram v1.1.1/go.mod h1:RaEWvsqvNKKvBPvcKeFjrG2cJqOkHTiyTpzz23ni57g=
 github.com/xdg-go/stringprep v1.0.2/go.mod h1:8F9zXuvzgwmyT5DUm4GUfZGDdT3W+LCvS6+da4O5kxM=
+github.com/xdg-go/stringprep v1.0.3/go.mod h1:W3f5j4i+9rC0kuIEJL0ky1VpHXQU3ocBgklLGvcBnW8=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
 github.com/xeipuuv/gojsonschema v0.0.0-20180618132009-1d523034197f/go.mod h1:5yf86TLmAcydyeJq5YvxkGPE2fm/u4myDekKRoLuqhs=
@@ -1364,6 +1393,7 @@ github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
+github.com/yuin/goldmark v1.4.1/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yusufpapurcu/wmi v1.2.2 h1:KBNDSne4vP5mbSWnJbO+51IMOXJB67QiYCSBrubbPRg=
 github.com/yusufpapurcu/wmi v1.2.2/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
 github.com/yvasiyarov/go-metrics v0.0.0-20140926110328-57bccd1ccd43/go.mod h1:aX5oPXxHm3bOH+xeAttToC8pqch2ScQN/JoXYupl6xs=
@@ -1445,6 +1475,8 @@ golang.org/x/crypto v0.0.0-20220214200702-86341886e292/go.mod h1:IxCIyHEi3zRg3s0
 golang.org/x/crypto v0.0.0-20220331220935-ae2d96664a29/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.0.0-20220411220226-7b82a4e95df4 h1:kUhD7nTDoI3fVd9G4ORWrbV5NY0liEs/Jg2pv5f+bBA=
 golang.org/x/crypto v0.0.0-20220411220226-7b82a4e95df4/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
+golang.org/x/crypto v0.0.0-20220513210258-46612604a0f9 h1:NUzdAbFtCJSXU20AOXgeqaUwg8Ypg4MPYmL+d+rsB5c=
+golang.org/x/crypto v0.0.0-20220513210258-46612604a0f9/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/exp v0.0.0-20180321215751-8460e604b9de/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20180807140117-3d87b88a115f/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -1459,6 +1491,7 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
+golang.org/x/exp v0.0.0-20220426173459-3bcf042a4bf5/go.mod h1:lgLbSvA5ygNOMpwM/9anMpWVlVJ7Z+cHWq/eFuinpGE=
 golang.org/x/image v0.0.0-20180708004352-c73c2afc3b81/go.mod h1:ux5Hcp/YLpHSI86hEcLt0YII63i6oz57MZXIpbrjZUs=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
@@ -1492,6 +1525,8 @@ golang.org/x/mod v0.4.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.1/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.5.0/go.mod h1:5OXOZSfqPIIbmVBIIKWRFfZjPR0E5r58TLhUjH0a2Ro=
+golang.org/x/mod v0.5.1/go.mod h1:5OXOZSfqPIIbmVBIIKWRFfZjPR0E5r58TLhUjH0a2Ro=
+golang.org/x/mod v0.6.0-dev.0.20211013180041-c96bc1413d57/go.mod h1:3p9vT2HGsQu2K1YbXdKPJLVgG5VJdoTa1poYQBtP1AY=
 golang.org/x/net v0.0.0-20180218175443-cbe0f9307d01/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180719180050-a680a1efc54d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -1562,6 +1597,7 @@ golang.org/x/net v0.0.0-20210614182718-04defd469f4e/go.mod h1:9nx3DQGgdP8bBQD5qx
 golang.org/x/net v0.0.0-20210805182204-aaa1db679c0d/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210813160813-60bc85c4be6d/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211013171255-e13a2654a71e/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211029224645-99673261e6eb/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211216030914-fe4d6282115f/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
@@ -1571,6 +1607,8 @@ golang.org/x/net v0.0.0-20220325170049-de3da57026de/go.mod h1:CfG3xpIq0wQ8r1q4Su
 golang.org/x/net v0.0.0-20220412020605-290c469a71a5/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/net v0.0.0-20220418201149-a630d4f3e7a2 h1:6mzvA99KwZxbOrxww4EvWVQUnN1+xEu9tafK5ZxkYeA=
 golang.org/x/net v0.0.0-20220418201149-a630d4f3e7a2/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
+golang.org/x/net v0.0.0-20220516155154-20f960328961 h1:+W/iTMPG0EL7aW+/atntZwZrvSRIj3m3yX414dSULUU=
+golang.org/x/net v0.0.0-20220516155154-20f960328961/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/oauth2 v0.0.0-20180227000427-d7d64896b5ff/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20181106182150-f42d05182288/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -1726,6 +1764,7 @@ golang.org/x/sys v0.0.0-20210908233432-aa78b53d3365/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211007075335-d3039528d8ac/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211013075003-97ac67df715c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20211019181941-9d821ace8654/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211124211545-fe61309f8881/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211205182925-97ca703d548d/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211210111614-af8b64212486/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
@@ -1737,6 +1776,9 @@ golang.org/x/sys v0.0.0-20220328115105-d36c6a25d886/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220403205710-6acee93ad0eb/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220412211240-33da011f77ad h1:ntjMns5wyP/fN65tdBD4g8J5w8n015+iIIs9rtjXkY0=
 golang.org/x/sys v0.0.0-20220412211240-33da011f77ad/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220513210249-45d2b4557a2a h1:N2T1jUrTQE9Re6TFF5PhvEHXHCguynGhKjWVsIUt5cY=
+golang.org/x/sys v0.0.0-20220513210249-45d2b4557a2a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
@@ -1834,6 +1876,7 @@ golang.org/x/tools v0.1.2/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.3/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.4/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.5/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
+golang.org/x/tools v0.1.8-0.20211029000441-d6a9af8af023/go.mod h1:nABZi5QlRsZVlzPpHl034qft6wpY4eDcsTt5AaioBiU=
 golang.org/x/xerrors v0.0.0-20190410155217-1f06c39b4373/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20190513163551-3ee3066db522/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
@@ -2076,6 +2119,8 @@ gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C
 gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b h1:h8qDotaEPuJATrMmW04NCwg7v22aHH28wwpauUhK9Oo=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.0-20220512140231-539c8e751b99 h1:dbuHpmKjkDzSOMKAWl10QNlgaZUd3V1q99xc81tt2Kc=
+gopkg.in/yaml.v3 v3.0.0-20220512140231-539c8e751b99/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gorm.io/driver/postgres v1.0.8/go.mod h1:4eOzrI1MUfm6ObJU/UcmbXyiHSs8jSwH95G5P5dxcAg=
 gorm.io/gorm v1.20.12/go.mod h1:0HFTzE/SqkGTzK6TlDPPQbAYCluiVvhzoA1+aVyzenw=
 gorm.io/gorm v1.21.4/go.mod h1:0HFTzE/SqkGTzK6TlDPPQbAYCluiVvhzoA1+aVyzenw=

--- a/internal/events/block_confirmations_test.go
+++ b/internal/events/block_confirmations_test.go
@@ -466,7 +466,7 @@ func TestConfirmationsListenerFailPollingBlocks(t *testing.T) {
 	}).Return(nil).Once()
 	rpc.On("CallContext", mock.Anything, mock.Anything, "eth_getFilterChanges", mock.MatchedBy(func(i hexutil.Big) bool {
 		return i.ToInt().Int64() == 1977
-	})).Return(fmt.Errorf("pop")).Once()
+	})).Return(fmt.Errorf("pop"))
 
 	bcm.confirmationsListener()
 
@@ -487,7 +487,7 @@ func TestConfirmationsListenerLostFilterReestablish(t *testing.T) {
 	rpc.On("CallContext", mock.Anything, mock.Anything, "eth_getFilterChanges", mock.MatchedBy(func(i hexutil.Big) bool {
 		bcm.cancelFunc()
 		return i.ToInt().Int64() == 1977
-	})).Return(nil).Once()
+	})).Return(nil)
 
 	bcm.confirmationsListener()
 
@@ -517,7 +517,6 @@ func TestConfirmationsListenerFailWalkingChainForNewEvent(t *testing.T) {
 
 	rpc.On("CallContext", mock.Anything, mock.Anything, "eth_newBlockFilter").Run(func(args mock.Arguments) {
 		args[1].(*hexutil.Big).ToInt().SetString("1977", 10)
-		bcm.cancelFunc()
 	}).Return(nil).Once()
 	rpc.On("CallContext", mock.Anything, mock.Anything, "eth_getFilterChanges", mock.MatchedBy(func(i hexutil.Big) bool {
 		return i.ToInt().Int64() == int64(1977)
@@ -525,8 +524,9 @@ func TestConfirmationsListenerFailWalkingChainForNewEvent(t *testing.T) {
 		*(args[1].(*[]*ethbinding.Hash)) = []*ethbinding.Hash{}
 	}).Return(nil)
 	rpc.On("CallContext", mock.Anything, mock.Anything, "eth_getBlockByNumber", mock.MatchedBy(func(i hexutil.Uint64) bool {
+		bcm.cancelFunc()
 		return uint64(i) == 1002
-	}), false).Return(fmt.Errorf("pop")).Once()
+	}), false).Return(fmt.Errorf("pop"))
 
 	bcm.confirmationsListener()
 

--- a/internal/events/submanager_test.go
+++ b/internal/events/submanager_test.go
@@ -229,11 +229,8 @@ func TestActionChildCleanup(t *testing.T) {
 
 	blockCall := make(chan struct{})
 	rpc := &ethmocks.RPCClient{}
-	rpc.On("CallContext", mock.Anything, mock.Anything, mock.Anything).Run(func(args mock.Arguments) { <-blockCall }).Return(nil)
+	rpc.On("CallContext", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Run(func(args mock.Arguments) { <-blockCall }).Return(nil)
 	rpc.On("CallContext", mock.Anything, mock.Anything, "eth_newFilter", mock.Anything).Return(nil)
-	rpc.On("CallContext", mock.Anything, mock.Anything, "eth_getFilterLogs", mock.Anything).Return(nil).Maybe()
-	rpc.On("CallContext", mock.Anything, mock.Anything, "eth_getFilterChanges", mock.Anything).Return(nil).Maybe()
-	rpc.On("CallContext", mock.Anything, mock.Anything, "eth_uninstallFilter", mock.Anything).Return(nil).Maybe()
 	sm.rpc = rpc
 
 	sm.db, _ = kvstore.NewLDBKeyValueStore(path.Join(dir, "db"))
@@ -266,11 +263,7 @@ func TestStreamAndSubscriptionErrors(t *testing.T) {
 
 	blockCall := make(chan struct{})
 	rpc := &ethmocks.RPCClient{}
-	rpc.On("CallContext", mock.Anything, mock.Anything, "eth_newFilter", mock.Anything).Return(nil).Maybe()
-	rpc.On("CallContext", mock.Anything, mock.Anything, "eth_getFilterLogs", mock.Anything).Return(nil).Maybe()
-	rpc.On("CallContext", mock.Anything, mock.Anything, "eth_getFilterChanges", mock.Anything).Return(nil).Maybe()
-	rpc.On("CallContext", mock.Anything, mock.Anything, mock.Anything).Run(func(args mock.Arguments) { <-blockCall }).Return(nil)
-	rpc.On("CallContext", mock.Anything, mock.Anything, "eth_uninstallFilter", mock.Anything).Return(nil).Maybe()
+	rpc.On("CallContext", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Run(func(args mock.Arguments) { <-blockCall }).Return(nil)
 	sm.rpc = rpc
 
 	sm.db, _ = kvstore.NewLDBKeyValueStore(path.Join(dir, "db"))

--- a/internal/events/submanager_test.go
+++ b/internal/events/submanager_test.go
@@ -142,6 +142,7 @@ func TestActionAndSubscriptionLifecycle(t *testing.T) {
 	rpc.On("CallContext", mock.Anything, mock.Anything, "eth_blockNumber").Return(nil)
 	rpc.On("CallContext", mock.Anything, mock.Anything, "eth_newFilter", mock.Anything).Return(nil)
 	rpc.On("CallContext", mock.Anything, mock.Anything, "eth_getFilterLogs", mock.Anything).Return(nil)
+	rpc.On("CallContext", mock.Anything, mock.Anything, "eth_getFilterChanges", mock.Anything).Return(nil).Maybe()
 	rpc.On("CallContext", mock.Anything, mock.Anything, "eth_uninstallFilter", mock.Anything).Return(nil)
 	rpc.On("CallContext", mock.Anything, mock.Anything, "eth_uninstallFilter", mock.Anything).Return(nil).Maybe()
 
@@ -231,6 +232,7 @@ func TestActionChildCleanup(t *testing.T) {
 	rpc.On("CallContext", mock.Anything, mock.Anything, mock.Anything).Run(func(args mock.Arguments) { <-blockCall }).Return(nil)
 	rpc.On("CallContext", mock.Anything, mock.Anything, "eth_newFilter", mock.Anything).Return(nil)
 	rpc.On("CallContext", mock.Anything, mock.Anything, "eth_getFilterLogs", mock.Anything).Return(nil).Maybe()
+	rpc.On("CallContext", mock.Anything, mock.Anything, "eth_getFilterChanges", mock.Anything).Return(nil).Maybe()
 	rpc.On("CallContext", mock.Anything, mock.Anything, "eth_uninstallFilter", mock.Anything).Return(nil).Maybe()
 	sm.rpc = rpc
 
@@ -266,6 +268,7 @@ func TestStreamAndSubscriptionErrors(t *testing.T) {
 	rpc := &ethmocks.RPCClient{}
 	rpc.On("CallContext", mock.Anything, mock.Anything, "eth_newFilter", mock.Anything).Return(nil).Maybe()
 	rpc.On("CallContext", mock.Anything, mock.Anything, "eth_getFilterLogs", mock.Anything).Return(nil).Maybe()
+	rpc.On("CallContext", mock.Anything, mock.Anything, "eth_getFilterChanges", mock.Anything).Return(nil).Maybe()
 	rpc.On("CallContext", mock.Anything, mock.Anything, mock.Anything).Run(func(args mock.Arguments) { <-blockCall }).Return(nil)
 	rpc.On("CallContext", mock.Anything, mock.Anything, "eth_uninstallFilter", mock.Anything).Return(nil).Maybe()
 	sm.rpc = rpc
@@ -423,6 +426,7 @@ func TestAddSubscriptionConcurrently(t *testing.T) {
 	rpc.On("CallContext", mock.Anything, mock.Anything, "eth_blockNumber").Return(nil)
 	rpc.On("CallContext", mock.Anything, mock.Anything, "eth_newFilter", mock.Anything).Return(nil)
 	rpc.On("CallContext", mock.Anything, mock.Anything, "eth_getFilterLogs", mock.Anything).Return(nil)
+	rpc.On("CallContext", mock.Anything, mock.Anything, "eth_getFilterChanges", mock.Anything).Return(nil).Maybe()
 	rpc.On("CallContext", mock.Anything, mock.Anything, "eth_uninstallFilter", mock.Anything).Return(nil)
 
 	sm.rpc = rpc

--- a/internal/ffcapiconnector/create_block_listener_test.go
+++ b/internal/ffcapiconnector/create_block_listener_test.go
@@ -45,6 +45,7 @@ func TestCreateBlockListenerOK(t *testing.T) {
 		Run(func(args mock.Arguments) {
 			(args[1].(*ethbinding.HexBigInt)).ToInt().SetString("12345", 10)
 		})
+	mRPC.On("CallContext", mock.Anything, mock.Anything, "eth_getFilterChanges", mock.Anything).Return(nil).Maybe()
 
 	iRes, reason, err := s.createBlockListener(ctx, []byte(sampleCreateBlockListener))
 	assert.NoError(t, err)

--- a/internal/tx/addressbook.go
+++ b/internal/tx/addressbook.go
@@ -46,9 +46,9 @@ type AddressBookConf struct {
 	AddressbookURLPrefix    string                   `json:"urlPrefix"`
 	HostsFile               string                   `json:"hostsFile"`
 	PropNames               AddressBookPropNamesConf `json:"propNames"`
-	RetryDelaySec           *int                     `json:"retryDelaySec"`
-	HealthcheckFrequencySec *int                     `json:"healthcheckFrequencySec"`
-	MaxRetries              *int                     `json:"maxRetries"`
+	RetryDelaySec           *int                     `json:"retryDelaySec,omitempty"`
+	HealthcheckFrequencySec *int                     `json:"healthcheckFrequencySec,omitempty"`
+	MaxRetries              *int                     `json:"maxRetries,omitempty"`
 }
 
 // AddressBookPropNamesConf configures the JSON property names to extract from the GET response on the API

--- a/internal/tx/addressbook.go
+++ b/internal/tx/addressbook.go
@@ -28,10 +28,10 @@ import (
 )
 
 const (
-	defaultRPCEndpointProp      = "endpoint"
-	defaultHealthcheckFrequency = 30 * time.Second
-	defaultRetryDelay           = 3 * time.Second
-	defaultMaxRetries           = 100
+	defaultRPCEndpointProp       = "endpoint"
+	defaultHealthcheckFrequency  = 30 * time.Second
+	defaultAddressbookRetryDelay = 3 * time.Second
+	defaultAddressbookMaxRetries = 100
 )
 
 // AddressBook looks up RPC URLs based on a remote registry, and optionally
@@ -76,11 +76,11 @@ func NewAddressBook(conf *AddressBookConf, rpcConf *eth.RPCConf) AddressBook {
 	if ab.conf.HealthcheckFrequencySec != nil {
 		ab.healthcheckFrequency = time.Duration(*ab.conf.HealthcheckFrequencySec) * time.Second
 	}
-	ab.retryDelay = defaultRetryDelay
+	ab.retryDelay = defaultAddressbookRetryDelay
 	if ab.conf.RetryDelaySec != nil {
 		ab.retryDelay = time.Duration(*ab.conf.RetryDelaySec) * time.Second
 	}
-	ab.maxRetries = defaultMaxRetries
+	ab.maxRetries = defaultAddressbookMaxRetries
 	if ab.conf.MaxRetries != nil {
 		ab.maxRetries = *ab.conf.MaxRetries
 	}

--- a/internal/tx/addressbook_test.go
+++ b/internal/tx/addressbook_test.go
@@ -48,11 +48,15 @@ func TestNewAddressBookCustomPropNames(t *testing.T) {
 			RPCEndpoint: "rpcEndpointProp",
 		},
 		HealthcheckFrequencySec: &ten,
+		RetryDelaySec:           &ten,
+		MaxRetries:              &ten,
 	}, &eth.RPCConf{})
 	ab := a.(*addressBook)
 	assert.Equal("http://localhost:12345/", ab.conf.AddressbookURLPrefix)
 	assert.Equal("rpcEndpointProp", ab.conf.PropNames.RPCEndpoint)
 	assert.Equal(10*time.Second, ab.healthcheckFrequency)
+	assert.Equal(10*time.Second, ab.retryDelay)
+	assert.Equal(10, ab.maxRetries)
 }
 
 func TestLookupWithCaching(t *testing.T) {
@@ -254,18 +258,21 @@ func TestLookupFailureResponse(t *testing.T) {
 	serverURL = server.URL
 	defer server.Close()
 
+	one := 1
 	a := NewAddressBook(&AddressBookConf{
 		AddressbookURLPrefix: serverURL + "/addresses",
 		PropNames: AddressBookPropNamesConf{
 			RPCEndpoint: "rpcEndpointProp",
 		},
+		MaxRetries: &one,
 	}, &eth.RPCConf{})
 	ab := a.(*addressBook)
+	ab.retryDelay = 0
 
 	log.SetLevel(log.DebugLevel)
 	_, err := ab.lookup(context.Background(), "0xdb0997dccd71607bd6ee378723a12ef8478e4ed6")
 
-	assert.Regexp("Could not process Addressbook \\[500\\] response", err)
+	assert.Regexp("FFEC100002", err)
 
 }
 

--- a/internal/tx/txnprocessor.go
+++ b/internal/tx/txnprocessor.go
@@ -151,7 +151,8 @@ func (p *txnProcessor) OnMessage(txnContext TxnContext) {
 
 	var unmarshalErr error
 	headers := txnContext.Headers()
-	log.Debugf("Processing %+v", headers)
+	log.Infof("--> OnMessage %s", headers.ID)
+	defer log.Infof("<-- OnMessage %s", headers.ID)
 	switch headers.MsgType {
 	case messages.MsgTypeDeployContract:
 		var deployContractMsg messages.DeployContract
@@ -574,6 +575,9 @@ func (p *txnProcessor) sendTransactionCommon(txnContext TxnContext, inflight *in
 }
 
 func (p *txnProcessor) sendAndTrackMining(txnContext TxnContext, inflight *inflightTxn, tx *eth.Txn) {
+
+	log.Infof("--> sending %s/%d (concurrency=%d)", inflight.from, inflight.nonce, p.conf.SendConcurrency)
+	defer log.Infof("<-- sent %s/%d", inflight.from, inflight.nonce)
 
 	// If the RPC client is nil here, we need to resolve it.
 	if inflight.rpc == nil {

--- a/internal/tx/txnprocessor_test.go
+++ b/internal/tx/txnprocessor_test.go
@@ -1182,10 +1182,12 @@ func TestOnSendTransactionAddressBook(t *testing.T) {
 func TestOnDeployContractMessageFailAddressLookup(t *testing.T) {
 	assert := assert.New(t)
 
+	zero := 0
 	txnProcessor := NewTxnProcessor(&TxnProcessorConf{
 		MaxTXWaitTime: 1,
 		AddressBookConf: AddressBookConf{
 			AddressbookURLPrefix: "   ",
+			MaxRetries:           &zero,
 		},
 	}, &eth.RPCConf{}).(*txnProcessor)
 	testTxnContext := &testTxnContext{}
@@ -1200,7 +1202,7 @@ func TestOnDeployContractMessageFailAddressLookup(t *testing.T) {
 		time.Sleep(1 * time.Millisecond)
 	}
 
-	assert.Regexp("Error querying Addressbook", testTxnContext.errorReplies[0].err)
+	assert.Regexp("FFEC100002", testTxnContext.errorReplies[0].err)
 
 }
 

--- a/internal/tx/txnprocessor_test.go
+++ b/internal/tx/txnprocessor_test.go
@@ -260,11 +260,37 @@ func TestOnDeployContractMessageBadJSON(t *testing.T) {
 	assert.Regexp("invalid character", testTxnContext.errorReplies[0].err.Error())
 
 }
+
+func TestInitSendRetryConfig(t *testing.T) {
+	assert := assert.New(t)
+
+	onePointFive := 1.5
+	five := 5
+	ten := 10
+	txnProcessor := NewTxnProcessor(&TxnProcessorConf{
+		SendRetryForce:      true,
+		SendRetryMax:        &ten,
+		SendRetryDelayMinMS: &five,
+		SendRetryDelayMaxMS: &ten,
+		SendRetryFactor:     &onePointFive,
+	}, &eth.RPCConf{}).(*txnProcessor)
+	txnProcessor.Init(&testRPC{})
+
+	assert.True(txnProcessor.sendRetryForce)
+	assert.Equal(10, txnProcessor.sendRetryMax)
+	assert.Equal(5*time.Millisecond, txnProcessor.sendRetryDelayMin)
+	assert.Equal(10*time.Millisecond, txnProcessor.sendRetryDelayMax)
+	assert.Equal(float64(1.5), txnProcessor.sendRetryFactor)
+
+}
+
 func TestOnDeployContractMessageGoodTxnErrOnReceipt(t *testing.T) {
 	assert := assert.New(t)
 
+	zero := 0
 	txnProcessor := NewTxnProcessor(&TxnProcessorConf{
 		MaxTXWaitTime: 1,
+		SendRetryMax:  &zero,
 	}, &eth.RPCConf{}).(*txnProcessor)
 	testTxnContext := &testTxnContext{}
 	testTxnContext.jsonMsg = goodDeployTxnJSON
@@ -323,8 +349,10 @@ func goodMessageRPC() *testRPC {
 func TestOnDeployContractMessageGoodTxnMined(t *testing.T) {
 	assert := assert.New(t)
 
+	zero := 0
 	txnProcessor := NewTxnProcessor(&TxnProcessorConf{
 		MaxTXWaitTime: 1,
+		SendRetryMax:  &zero,
 	}, &eth.RPCConf{}).(*txnProcessor)
 	testTxnContext := &testTxnContext{}
 	testTxnContext.jsonMsg = goodDeployTxnJSON
@@ -383,11 +411,13 @@ func TestOnDeployContractMessageGoodTxnMinedHDWallet(t *testing.T) {
 	}))
 	defer svr.Close()
 
+	zero := 0
 	txnProcessor := NewTxnProcessor(&TxnProcessorConf{
 		MaxTXWaitTime: 1,
 		HDWalletConf: HDWalletConf{
 			URLTemplate: svr.URL,
 		},
+		SendRetryMax: &zero,
 	}, &eth.RPCConf{}).(*txnProcessor)
 	testTxnContext := &testTxnContext{}
 	testTxnContext.jsonMsg = goodHDWalletDeployTxnJSON
@@ -430,7 +460,9 @@ func TestOnDeployContractMessageGoodTxnMinedHDWallet(t *testing.T) {
 func TestOnDeployContractPrivateMessageGoodTxnMined(t *testing.T) {
 	assert := assert.New(t)
 
+	zero := 0
 	txnProcessor := NewTxnProcessor(&TxnProcessorConf{
+		SendRetryMax:  &zero,
 		MaxTXWaitTime: 1,
 	}, &eth.RPCConf{}).(*txnProcessor)
 	testTxnContext := &testTxnContext{}
@@ -478,9 +510,11 @@ func TestOnDeployContractPrivateMessageGoodTxnMined(t *testing.T) {
 func TestOnDeployContractMessageGoodTxnMinedWithHex(t *testing.T) {
 	assert := assert.New(t)
 
+	zero := 0
 	txnProcessor := NewTxnProcessor(&TxnProcessorConf{
 		MaxTXWaitTime:      1,
 		HexValuesInReceipt: true,
+		SendRetryMax:       &zero,
 	}, &eth.RPCConf{}).(*txnProcessor)
 	testTxnContext := &testTxnContext{}
 	testTxnContext.jsonMsg = goodDeployTxnJSON
@@ -528,8 +562,10 @@ func TestOnDeployContractMessageGoodTxnMinedWithHex(t *testing.T) {
 func TestOnDeployContractMessageFailedTxnMined(t *testing.T) {
 	assert := assert.New(t)
 
+	zero := 0
 	txnProcessor := NewTxnProcessor(&TxnProcessorConf{
 		MaxTXWaitTime: 1,
+		SendRetryMax:  &zero,
 	}, &eth.RPCConf{}).(*txnProcessor)
 	testTxnContext := &testTxnContext{}
 	testTxnContext.jsonMsg = goodDeployTxnJSON
@@ -554,8 +590,10 @@ func TestOnDeployContractMessageFailedTxnMined(t *testing.T) {
 func TestOnDeployContractMessageFailedTxn(t *testing.T) {
 	assert := assert.New(t)
 
+	zero := 0
 	txnProcessor := NewTxnProcessor(&TxnProcessorConf{
 		MaxTXWaitTime: 5000,
+		SendRetryMax:  &zero,
 	}, &eth.RPCConf{}).(*txnProcessor)
 	testTxnContext := &testTxnContext{}
 	testTxnContext.jsonMsg = goodDeployTxnJSON
@@ -576,8 +614,10 @@ func TestOnDeployContractMessageFailedTxn(t *testing.T) {
 func TestOnDeployContractMessageFailedToGetNonce(t *testing.T) {
 	assert := assert.New(t)
 
+	zero := 0
 	txnProcessor := NewTxnProcessor(&TxnProcessorConf{
 		MaxTXWaitTime: 1,
+		SendRetryMax:  &zero,
 	}, &eth.RPCConf{}).(*txnProcessor)
 	txnProcessor.conf.AlwaysManageNonce = true
 	testTxnContext := &testTxnContext{}
@@ -684,17 +724,19 @@ func TestOnSendTransactionMessageBadJSON(t *testing.T) {
 func TestOnSendTransactionMessageTxnTimeout(t *testing.T) {
 	assert := assert.New(t)
 
+	zero := 0
 	txHash := "0xac18e98664e160305cdb77e75e5eae32e55447e94ad8ceb0123729589ed09f8b"
 	txnProcessor := NewTxnProcessor(&TxnProcessorConf{
 		MaxTXWaitTime: 1,
+		SendRetryMax:  &zero,
 	}, &eth.RPCConf{}).(*txnProcessor)
 	testTxnContext := &testTxnContext{}
 	testTxnContext.jsonMsg = goodSendTxnJSON
 	testRPC := &testRPC{
 		ethSendTransactionResult: txHash,
 	}
-	txnProcessor.Init(testRPC)                          // configured in seconds for real world
-	txnProcessor.maxTXWaitTime = 250 * time.Millisecond // ... but fail asap for this test
+	txnProcessor.Init(testRPC)                         // configured in seconds for real world
+	txnProcessor.maxTXWaitTime = 10 * time.Millisecond // ... but fail asap for this test
 
 	txnProcessor.OnMessage(testTxnContext)
 	for inMap := false; !inMap; _, inMap = txnProcessor.inflightTxns[strings.ToLower(testFromAddr)] {
@@ -715,8 +757,10 @@ func TestOnSendTransactionMessageTxnTimeout(t *testing.T) {
 func TestOnSendTransactionMessageFailedTxn(t *testing.T) {
 	assert := assert.New(t)
 
+	zero := 0
 	txnProcessor := NewTxnProcessor(&TxnProcessorConf{
 		MaxTXWaitTime: 1,
+		SendRetryMax:  &zero,
 	}, &eth.RPCConf{}).(*txnProcessor)
 	testTxnContext := &testTxnContext{}
 	testTxnContext.jsonMsg = goodSendTxnJSON
@@ -737,11 +781,13 @@ func TestOnSendTransactionMessageFailedTxn(t *testing.T) {
 func TestOnSendTransactionMessageFailedWithGapFillOK(t *testing.T) {
 	assert := assert.New(t)
 
+	zero := 0
 	txnProcessor := NewTxnProcessor(&TxnProcessorConf{
 		MaxTXWaitTime:     1,
 		SendConcurrency:   10,
 		AlwaysManageNonce: true,
 		AttemptGapFill:    true,
+		SendRetryMax:      &zero,
 	}, &eth.RPCConf{}).(*txnProcessor)
 	testRPC := goodMessageRPC()
 	testRPC.ethSendTransactionErr = fmt.Errorf("pop")
@@ -797,11 +843,13 @@ func TestOnSendTransactionMessageFailedWithGapFillOK(t *testing.T) {
 func TestOnSendTransactionMessageFailedWithGapFillFail(t *testing.T) {
 	assert := assert.New(t)
 
+	zero := 0
 	txnProcessor := NewTxnProcessor(&TxnProcessorConf{
 		MaxTXWaitTime:     1,
 		SendConcurrency:   10,
 		AlwaysManageNonce: true,
 		AttemptGapFill:    true,
+		SendRetryMax:      &zero,
 	}, &eth.RPCConf{}).(*txnProcessor)
 	testRPC := goodMessageRPC()
 	testRPC.ethSendTransactionErr = fmt.Errorf("pop")
@@ -857,8 +905,10 @@ func TestOnSendTransactionMessageFailedWithGapFillFail(t *testing.T) {
 func TestOnSendTransactionMessageFailedToGetNonce(t *testing.T) {
 	assert := assert.New(t)
 
+	zero := 0
 	txnProcessor := NewTxnProcessor(&TxnProcessorConf{
 		MaxTXWaitTime: 1,
+		SendRetryMax:  &zero,
 	}, &eth.RPCConf{}).(*txnProcessor)
 	txnProcessor.conf.AlwaysManageNonce = true
 	testTxnContext := &testTxnContext{}
@@ -883,9 +933,11 @@ func TestOnSendTransactionMessageFailedToGetNonce(t *testing.T) {
 func TestOnSendTransactionMessageInflightNonce(t *testing.T) {
 	assert := assert.New(t)
 
+	zero := 0
 	txnProcessor := NewTxnProcessor(&TxnProcessorConf{
 		MaxTXWaitTime:     1,
 		AlwaysManageNonce: true,
+		SendRetryMax:      &zero,
 	}, &eth.RPCConf{}).(*txnProcessor)
 	txnProcessor.inflightTxns["0x83dbc8e329b38cba0fc4ed99b1ce9c2a390abdc1"] = &inflightTxnState{}
 	txnProcessor.inflightTxns["0x83dbc8e329b38cba0fc4ed99b1ce9c2a390abdc1"].txnsInFlight = []*inflightTxn{{nonce: 100}, {nonce: 101}}
@@ -915,8 +967,10 @@ func TestOnSendTransactionMessageInflightNonce(t *testing.T) {
 func TestOnSendTransactionMessageFailedToEstimateGas(t *testing.T) {
 	assert := assert.New(t)
 
+	zero := 0
 	txnProcessor := NewTxnProcessor(&TxnProcessorConf{
 		MaxTXWaitTime: 1,
+		SendRetryMax:  &zero,
 	}, &eth.RPCConf{}).(*txnProcessor)
 	txnProcessor.conf.AlwaysManageNonce = true
 	testRPC := goodMessageRPC()
@@ -959,8 +1013,10 @@ func TestOnSendTransactionMessageFailedToEstimateGas(t *testing.T) {
 func TestOnSendTransactionMessageOrionNoPrivacyGroup(t *testing.T) {
 	assert := assert.New(t)
 
+	zero := 0
 	txnProcessor := NewTxnProcessor(&TxnProcessorConf{
 		OrionPrivateAPIS: true,
+		SendRetryMax:     &zero,
 	}, &eth.RPCConf{}).(*txnProcessor)
 	testTxnContext := &testTxnContext{}
 	testTxnContext.jsonMsg = "{" +
@@ -989,8 +1045,10 @@ func TestOnSendTransactionMessageOrionNoPrivacyGroup(t *testing.T) {
 func TestOnSendTransactionMessageOrionCannotUsePrivacyGroupIdAndPrivateFor(t *testing.T) {
 	assert := assert.New(t)
 
+	zero := 0
 	txnProcessor := NewTxnProcessor(&TxnProcessorConf{
 		OrionPrivateAPIS: true,
+		SendRetryMax:     &zero,
 	}, &eth.RPCConf{}).(*txnProcessor)
 	testTxnContext := &testTxnContext{}
 	testTxnContext.jsonMsg = "{" +
@@ -1015,9 +1073,11 @@ func TestOnSendTransactionMessageOrionCannotUsePrivacyGroupIdAndPrivateFor(t *te
 func TestOnSendTransactionMessageOrionFailNonce(t *testing.T) {
 	assert := assert.New(t)
 
+	zero := 0
 	txnProcessor := NewTxnProcessor(&TxnProcessorConf{
 		MaxTXWaitTime:    1,
 		OrionPrivateAPIS: true,
+		SendRetryMax:     &zero,
 	}, &eth.RPCConf{}).(*txnProcessor)
 	txnProcessor.inflightTxns["0x83dbc8e329b38cba0fc4ed99b1ce9c2a390abdc1"] = &inflightTxnState{}
 	txnProcessor.inflightTxns["0x83dbc8e329b38cba0fc4ed99b1ce9c2a390abdc1"].txnsInFlight = []*inflightTxn{{nonce: 100}, {nonce: 101}}
@@ -1053,9 +1113,11 @@ func TestOnSendTransactionMessageOrionFailNonce(t *testing.T) {
 func TestOnSendTransactionMessageOrion(t *testing.T) {
 	assert := assert.New(t)
 
+	zero := 0
 	txnProcessor := NewTxnProcessor(&TxnProcessorConf{
 		MaxTXWaitTime:    1,
 		OrionPrivateAPIS: true,
+		SendRetryMax:     &zero,
 	}, &eth.RPCConf{}).(*txnProcessor)
 	txnProcessor.inflightTxns["0x83dbc8e329b38cba0fc4ed99b1ce9c2a390abdc1"] = &inflightTxnState{}
 	txnProcessor.inflightTxns["0x83dbc8e329b38cba0fc4ed99b1ce9c2a390abdc1"].txnsInFlight = []*inflightTxn{{nonce: 100}, {nonce: 101}}
@@ -1090,9 +1152,11 @@ func TestOnSendTransactionMessageOrion(t *testing.T) {
 func TestOnSendTransactionMessageOrionPrivacyGroupId(t *testing.T) {
 	assert := assert.New(t)
 
+	zero := 0
 	txnProcessor := NewTxnProcessor(&TxnProcessorConf{
 		MaxTXWaitTime:    1,
 		OrionPrivateAPIS: true,
+		SendRetryMax:     &zero,
 	}, &eth.RPCConf{}).(*txnProcessor)
 	txnProcessor.inflightTxns["0x83dbc8e329b38cba0fc4ed99b1ce9c2a390abdc1"] = &inflightTxnState{}
 	txnProcessor.inflightTxns["0x83dbc8e329b38cba0fc4ed99b1ce9c2a390abdc1"].txnsInFlight = []*inflightTxn{{nonce: 100}, {nonce: 101}}
@@ -1145,12 +1209,14 @@ func TestOnSendTransactionAddressBook(t *testing.T) {
 	server := httptest.NewServer(router)
 	defer server.Close()
 
+	zero := 0
 	txnProcessor := NewTxnProcessor(&TxnProcessorConf{
 		MaxTXWaitTime:    1,
 		OrionPrivateAPIS: true,
 		AddressBookConf: AddressBookConf{
 			AddressbookURLPrefix: server.URL,
 		},
+		SendRetryMax: &zero,
 	}, &eth.RPCConf{
 		RPC: eth.RPCConnOpts{
 			URL: server.URL,
@@ -1209,8 +1275,10 @@ func TestOnDeployContractMessageFailAddressLookup(t *testing.T) {
 func TestOnDeployContractMessageFailHDWalletMissing(t *testing.T) {
 	assert := assert.New(t)
 
+	zero := 0
 	txnProcessor := NewTxnProcessor(&TxnProcessorConf{
 		MaxTXWaitTime: 1,
+		SendRetryMax:  &zero,
 	}, &eth.RPCConf{}).(*txnProcessor)
 	testTxnContext := &testTxnContext{}
 	testTxnContext.jsonMsg = goodHDWalletDeployTxnJSON
@@ -1231,9 +1299,11 @@ func TestOnDeployContractMessageFailHDWalletMissing(t *testing.T) {
 func TestOnDeployContractMessageFailHDWalletFail(t *testing.T) {
 	assert := assert.New(t)
 
+	zero := 0
 	txnProcessor := NewTxnProcessor(&TxnProcessorConf{
 		MaxTXWaitTime: 1,
 		HDWalletConf:  HDWalletConf{URLTemplate: "   "},
+		SendRetryMax:  &zero,
 	}, &eth.RPCConf{}).(*txnProcessor)
 	testTxnContext := &testTxnContext{}
 	testTxnContext.jsonMsg = goodHDWalletDeployTxnJSON
@@ -1303,4 +1373,89 @@ func TestResolveAddressHDWalletFail(t *testing.T) {
 
 	_, err := txnProcessor.ResolveAddress("hd-testinst-testwallet-1234")
 	assert.Regexp("No HD Wallet Configuration", err)
+}
+
+func TestSendRetryMax(t *testing.T) {
+	assert := assert.New(t)
+
+	one := 1
+	two := 2
+	three := 3
+	txnProcessor := NewTxnProcessor(&TxnProcessorConf{
+		SendRetryDelayMinMS: &one,
+		SendRetryDelayMaxMS: &two,
+		SendRetryMax:        &three,
+		SendConcurrency:     1,
+		AlwaysManageNonce:   true,
+	}, &eth.RPCConf{}).(*txnProcessor)
+
+	testTxnContext := &testTxnContext{}
+	testTxnContext.jsonMsg = goodSendTxnJSON
+	testRPC := &testRPC{
+		ethSendTransactionErr: fmt.Errorf("pop"),
+	}
+	txnProcessor.Init(testRPC)
+
+	txnProcessor.OnMessage(testTxnContext)
+
+	// Transaction count, followed by 4 attempts (3 retries)
+	assert.Equal([]string{"eth_getTransactionCount", "eth_sendTransaction", "eth_sendTransaction", "eth_sendTransaction", "eth_sendTransaction"}, testRPC.calls)
+
+}
+
+func TestSendRetryNoRetryNonce(t *testing.T) {
+	assert := assert.New(t)
+
+	one := 1
+	two := 2
+	three := 3
+	txnProcessor := NewTxnProcessor(&TxnProcessorConf{
+		SendRetryDelayMinMS: &one,
+		SendRetryDelayMaxMS: &two,
+		SendRetryMax:        &three,
+		SendConcurrency:     1,
+		AlwaysManageNonce:   true,
+	}, &eth.RPCConf{}).(*txnProcessor)
+
+	testTxnContext := &testTxnContext{}
+	testTxnContext.jsonMsg = goodSendTxnJSON
+	testRPC := &testRPC{
+		ethSendTransactionErr: fmt.Errorf("nonce too low"),
+	}
+	txnProcessor.Init(testRPC)
+
+	txnProcessor.OnMessage(testTxnContext)
+
+	// No retry
+	assert.Equal([]string{"eth_getTransactionCount", "eth_sendTransaction"}, testRPC.calls)
+
+}
+
+func TestSendRetryForce(t *testing.T) {
+	assert := assert.New(t)
+
+	one := 1
+	two := 2
+	three := 3
+	txnProcessor := NewTxnProcessor(&TxnProcessorConf{
+		SendRetryDelayMinMS: &one,
+		SendRetryDelayMaxMS: &two,
+		SendRetryMax:        &three,
+		SendConcurrency:     1,
+		AlwaysManageNonce:   true,
+		SendRetryForce:      true,
+	}, &eth.RPCConf{}).(*txnProcessor)
+
+	testTxnContext := &testTxnContext{}
+	testTxnContext.jsonMsg = goodSendTxnJSON
+	testRPC := &testRPC{
+		ethSendTransactionErr: fmt.Errorf("nonce"),
+	}
+	txnProcessor.Init(testRPC)
+
+	txnProcessor.OnMessage(testTxnContext)
+
+	// Transaction count, followed by 4 attempts (3 retries)
+	assert.Equal([]string{"eth_getTransactionCount", "eth_sendTransaction", "eth_sendTransaction", "eth_sendTransaction", "eth_sendTransaction"}, testRPC.calls)
+
 }


### PR DESCRIPTION
Three related changes from analysis of some performance tests:

1. The `sendConcurrency` setting is not currently providing the full concurrency support it was intended to. This is because the `concurrencySlots` channel was being allocated in the constructor of the `TxnProcessor` which is before `SetConf` is called. So we need to allocated it in `Init()`. This results in us using pipelining between the `Send` and in-flight nonce allocation, but not performing multiple `Send` calls in parallel. 

2. In the case that a `Send` fails due to an intermittent error, such as a timeout, this is problem for end-users because they do not know if the transaction was submitted or not. However, in cases where EthConnect is in control of the `nonce` it is safe for EthConnect to retry. So this PR introduces an option for retries, and enables these by default (with a small number - 5) to deal with glitches without pushing those errors all the way back to the requester.

3. Currently the addressbook lookup is performed on the single-threaded processing, before we dispatch a concurrent worker to the `inflight` action. As there is a JSON/RPC healthcheck call that is part of this (`net_version`) this is inefficient. So this PR moves it to the concurrent worker, after `inflight` is generated.