### PR TITLE
Correct the Upsert syntax for MongoDB overwrite

### DIFF
--- a/internal/rest/mongoreceipts.go
+++ b/internal/rest/mongoreceipts.go
@@ -78,8 +78,7 @@ func (m *mongoReceipts) connect() (err error) {
 // To account for any transitory failures writing to mongoDB, it retries adding receipt with a backoff
 func (m *mongoReceipts) AddReceipt(requestID string, receipt *map[string]interface{}, overwrite bool) (err error) {
 	if overwrite {
-		query := m.collection.Find(bson.M{"_id": requestID})
-		return m.collection.Upsert(query, *receipt)
+		return m.collection.Upsert(bson.M{"_id": requestID}, *receipt)
 	} else {
 		return m.collection.Insert(*receipt)
 	}


### PR DESCRIPTION
If a still using Mongo DB (rather than the lighter weight / faster LevelDB option) for receipt stores, they will see the following error when receipts are inserted into the store, after upgrading to https://github.com/hyperledger/firefly-ethconnect/releases/tag/v3.2.2:

```
[2022-05-27T10:53:11.175-04:00]  INFO Received reply message. requestId='5fcc8464-17f5-4d8a-78ad-da554a7d388d' reqOffset='' type='TransactionFailure': 0xa8c748db42ca12662a4a94f3a23c4123712378e150ef847201a8c72980eb131a
[2022-05-27T10:53:11.175-04:00] ERROR 5fcc8464-17f5-4d8a-78ad-da554a7d388d: addReceipt attempt: 1 failed, err: reflect.Value.Interface: cannot return value obtained from unexported field or method
[2022-05-27T10:53:11.175-04:00]  INFO 5fcc8464-17f5-4d8a-78ad-da554a7d388d: Waiting 0.50s before re-attempt:1 mongo write
```