### PR TITLE
Do not require the filter id to be numeric

### DIFF
--- a/internal/events/block_confirmations.go
+++ b/internal/events/block_confirmations.go
@@ -37,7 +37,7 @@ type blockConfirmationManager struct {
 	ctx                   context.Context
 	cancelFunc            func()
 	log                   *log.Entry
-	filterID              ethbinding.HexBigInt
+	filterID              string
 	filterStale           bool
 	rpc                   eth.RPCClient
 	requiredConfirmations int
@@ -193,7 +193,7 @@ func (bcm *blockConfirmationManager) createBlockFilter() error {
 		return errors.Errorf(errors.RPCCallReturnedError, "eth_newBlockFilter", err)
 	}
 	bcm.filterStale = false
-	bcm.log.Infof("Created block filter: %s", bcm.filterID.String())
+	bcm.log.Infof("Created block filter: %s", bcm.filterID)
 	return err
 }
 

--- a/internal/events/block_confirmations_test.go
+++ b/internal/events/block_confirmations_test.go
@@ -94,12 +94,12 @@ func TestBlockConfirmationManagerE2ENewEvent(t *testing.T) {
 
 	// Establish the block filter
 	rpc.On("CallContext", mock.Anything, mock.Anything, "eth_newBlockFilter").Run(func(args mock.Arguments) {
-		args[1].(*hexutil.Big).ToInt().SetString("1977", 10)
+		*args[1].(*string) = "filter_id1"
 	}).Return(nil).Once()
 
 	// First poll for changes gives nothing, but we load up the event at this point for the next round
-	rpc.On("CallContext", mock.Anything, mock.Anything, "eth_getFilterChanges", mock.MatchedBy(func(i hexutil.Big) bool {
-		return i.ToInt().Int64() == int64(1977)
+	rpc.On("CallContext", mock.Anything, mock.Anything, "eth_getFilterChanges", mock.MatchedBy(func(f string) bool {
+		return f == "filter_id1"
 	})).Run(func(args mock.Arguments) {
 		*(args[1].(*[]*ethbinding.Hash)) = []*ethbinding.Hash{}
 
@@ -116,8 +116,8 @@ func TestBlockConfirmationManagerE2ENewEvent(t *testing.T) {
 		Hash:       ethbind.API.HexToHash("0x64fd8179b80dd255d52ce60d7f265c0506be810e2f3df52463fadeb44bb4d2df"),
 		ParentHash: ethbind.API.HexToHash("0x46210d224888265c269359529618bf2f6adb2697ff52c63c10f16a2391bdd295"),
 	}
-	rpc.On("CallContext", mock.Anything, mock.Anything, "eth_getFilterChanges", mock.MatchedBy(func(i hexutil.Big) bool {
-		return i.ToInt().Int64() == int64(1977)
+	rpc.On("CallContext", mock.Anything, mock.Anything, "eth_getFilterChanges", mock.MatchedBy(func(f string) bool {
+		return f == "filter_id1"
 	})).Run(func(args mock.Arguments) {
 		*(args[1].(*[]*ethbinding.Hash)) = []*ethbinding.Hash{
 			&block1003.Hash,
@@ -152,8 +152,8 @@ func TestBlockConfirmationManagerE2ENewEvent(t *testing.T) {
 		Hash:       ethbind.API.HexToHash("0xed21f4f73d150f16f922ae82b7485cd936ae1eca4c027516311b928360a347e8"),
 		ParentHash: ethbind.API.HexToHash("0x64fd8179b80dd255d52ce60d7f265c0506be810e2f3df52463fadeb44bb4d2df"),
 	}
-	rpc.On("CallContext", mock.Anything, mock.Anything, "eth_getFilterChanges", mock.MatchedBy(func(i hexutil.Big) bool {
-		return i.ToInt().Int64() == int64(1977)
+	rpc.On("CallContext", mock.Anything, mock.Anything, "eth_getFilterChanges", mock.MatchedBy(func(f string) bool {
+		return f == "filter_id1"
 	})).Run(func(args mock.Arguments) {
 		*(args[1].(*[]*ethbinding.Hash)) = []*ethbinding.Hash{
 			&block1004.Hash,
@@ -169,8 +169,8 @@ func TestBlockConfirmationManagerE2ENewEvent(t *testing.T) {
 	}).Return(nil).Once()
 
 	// Subsequent calls get nothing, and blocks until close anyway
-	rpc.On("CallContext", mock.Anything, mock.Anything, "eth_getFilterChanges", mock.MatchedBy(func(i hexutil.Big) bool {
-		return i.ToInt().Int64() == int64(1977)
+	rpc.On("CallContext", mock.Anything, mock.Anything, "eth_getFilterChanges", mock.MatchedBy(func(f string) bool {
+		return f == "filter_id1"
 	})).Run(func(args mock.Arguments) {
 		*(args[1].(*[]*ethbinding.Hash)) = []*ethbinding.Hash{}
 		if lastBlockDetected {
@@ -206,7 +206,7 @@ func TestBlockConfirmationManagerE2EFork(t *testing.T) {
 
 	// Establish the block filter
 	rpc.On("CallContext", mock.Anything, mock.Anything, "eth_newBlockFilter").Run(func(args mock.Arguments) {
-		args[1].(*hexutil.Big).ToInt().SetString("1977", 10)
+		*args[1].(*string) = "filter_id1"
 	}).Return(nil).Once()
 
 	// The next filter gives us 1002, and a first 1003 block - which will later be removed
@@ -220,8 +220,8 @@ func TestBlockConfirmationManagerE2EFork(t *testing.T) {
 		Hash:       ethbind.API.HexToHash("0x46210d224888265c269359529618bf2f6adb2697ff52c63c10f16a2391bdd295"),
 		ParentHash: ethbind.API.HexToHash("0x64fd8179b80dd255d52ce60d7f265c0506be810e2f3df52463fadeb44bb4d2df"),
 	}
-	rpc.On("CallContext", mock.Anything, mock.Anything, "eth_getFilterChanges", mock.MatchedBy(func(i hexutil.Big) bool {
-		return i.ToInt().Int64() == int64(1977)
+	rpc.On("CallContext", mock.Anything, mock.Anything, "eth_getFilterChanges", mock.MatchedBy(func(f string) bool {
+		return f == "filter_id1"
 	})).Run(func(args mock.Arguments) {
 		*(args[1].(*[]*ethbinding.Hash)) = []*ethbinding.Hash{
 			&block1002.Hash,
@@ -250,8 +250,8 @@ func TestBlockConfirmationManagerE2EFork(t *testing.T) {
 		Hash:       ethbind.API.HexToHash("0x110282339db2dfe4bfd13d78375f7883048cac6bc12f8393bd080a4e263d5d21"),
 		ParentHash: ethbind.API.HexToHash("0xed21f4f73d150f16f922ae82b7485cd936ae1eca4c027516311b928360a347e8"),
 	}
-	rpc.On("CallContext", mock.Anything, mock.Anything, "eth_getFilterChanges", mock.MatchedBy(func(i hexutil.Big) bool {
-		return i.ToInt().Int64() == int64(1977)
+	rpc.On("CallContext", mock.Anything, mock.Anything, "eth_getFilterChanges", mock.MatchedBy(func(f string) bool {
+		return f == "filter_id1"
 	})).Run(func(args mock.Arguments) {
 		*(args[1].(*[]*ethbinding.Hash)) = []*ethbinding.Hash{
 			&block1003b.Hash,
@@ -270,8 +270,8 @@ func TestBlockConfirmationManagerE2EFork(t *testing.T) {
 	}).Return(nil).Once()
 
 	// Subsequent calls get nothing, and blocks until close anyway
-	rpc.On("CallContext", mock.Anything, mock.Anything, "eth_getFilterChanges", mock.MatchedBy(func(i hexutil.Big) bool {
-		return i.ToInt().Int64() == int64(1977)
+	rpc.On("CallContext", mock.Anything, mock.Anything, "eth_getFilterChanges", mock.MatchedBy(func(f string) bool {
+		return f == "filter_id1"
 	})).Run(func(args mock.Arguments) {
 		*(args[1].(*[]*ethbinding.Hash)) = []*ethbinding.Hash{}
 		if lastBlockDetected {
@@ -322,12 +322,12 @@ func TestBlockConfirmationManagerE2EHistoricalEvent(t *testing.T) {
 
 	// Establish the block filter
 	rpc.On("CallContext", mock.Anything, mock.Anything, "eth_newBlockFilter").Run(func(args mock.Arguments) {
-		args[1].(*hexutil.Big).ToInt().SetString("1977", 10)
+		*args[1].(*string) = "filter_id1"
 	}).Return(nil).Once()
 
 	// We don't notify of any new blocks
-	rpc.On("CallContext", mock.Anything, mock.Anything, "eth_getFilterChanges", mock.MatchedBy(func(i hexutil.Big) bool {
-		return i.ToInt().Int64() == int64(1977)
+	rpc.On("CallContext", mock.Anything, mock.Anything, "eth_getFilterChanges", mock.MatchedBy(func(f string) bool {
+		return f == "filter_id1"
 	})).Run(func(args mock.Arguments) {
 		*(args[1].(*[]*ethbinding.Hash)) = []*ethbinding.Hash{}
 	}).Return(nil)
@@ -443,7 +443,7 @@ func TestConfirmationsListenerFailWalkingChain(t *testing.T) {
 	bcm.addEvent(eventToConfirm, testStream)
 
 	rpc.On("CallContext", mock.Anything, mock.Anything, "eth_newBlockFilter").Run(func(args mock.Arguments) {
-		args[1].(*hexutil.Big).ToInt().SetString("1977", 10)
+		*args[1].(*string) = "filter_id1"
 		bcm.cancelFunc()
 	}).Return(nil).Once()
 	rpc.On("CallContext", mock.Anything, mock.Anything, "eth_getBlockByNumber", mock.MatchedBy(func(i hexutil.Uint64) bool {
@@ -461,11 +461,11 @@ func TestConfirmationsListenerFailPollingBlocks(t *testing.T) {
 	bcm.done = make(chan struct{})
 
 	rpc.On("CallContext", mock.Anything, mock.Anything, "eth_newBlockFilter").Run(func(args mock.Arguments) {
-		args[1].(*hexutil.Big).ToInt().SetString("1977", 10)
+		*args[1].(*string) = "filter_id1"
 		bcm.cancelFunc()
 	}).Return(nil).Once()
-	rpc.On("CallContext", mock.Anything, mock.Anything, "eth_getFilterChanges", mock.MatchedBy(func(i hexutil.Big) bool {
-		return i.ToInt().Int64() == 1977
+	rpc.On("CallContext", mock.Anything, mock.Anything, "eth_getFilterChanges", mock.MatchedBy(func(f string) bool {
+		return f == "filter_id1"
 	})).Return(fmt.Errorf("pop"))
 
 	bcm.confirmationsListener()
@@ -479,14 +479,14 @@ func TestConfirmationsListenerLostFilterReestablish(t *testing.T) {
 	bcm.done = make(chan struct{})
 
 	rpc.On("CallContext", mock.Anything, mock.Anything, "eth_newBlockFilter").Run(func(args mock.Arguments) {
-		args[1].(*hexutil.Big).ToInt().SetString("1977", 10)
+		*args[1].(*string) = "filter_id1"
 	}).Return(nil).Twice()
-	rpc.On("CallContext", mock.Anything, mock.Anything, "eth_getFilterChanges", mock.MatchedBy(func(i hexutil.Big) bool {
-		return i.ToInt().Int64() == 1977
+	rpc.On("CallContext", mock.Anything, mock.Anything, "eth_getFilterChanges", mock.MatchedBy(func(f string) bool {
+		return f == "filter_id1"
 	})).Return(fmt.Errorf("filter not found")).Once()
-	rpc.On("CallContext", mock.Anything, mock.Anything, "eth_getFilterChanges", mock.MatchedBy(func(i hexutil.Big) bool {
+	rpc.On("CallContext", mock.Anything, mock.Anything, "eth_getFilterChanges", mock.MatchedBy(func(f string) bool {
 		bcm.cancelFunc()
-		return i.ToInt().Int64() == 1977
+		return f == "filter_id1"
 	})).Return(nil)
 
 	bcm.confirmationsListener()
@@ -516,10 +516,10 @@ func TestConfirmationsListenerFailWalkingChainForNewEvent(t *testing.T) {
 	})
 
 	rpc.On("CallContext", mock.Anything, mock.Anything, "eth_newBlockFilter").Run(func(args mock.Arguments) {
-		args[1].(*hexutil.Big).ToInt().SetString("1977", 10)
+		*args[1].(*string) = "filter_id1"
 	}).Return(nil).Once()
-	rpc.On("CallContext", mock.Anything, mock.Anything, "eth_getFilterChanges", mock.MatchedBy(func(i hexutil.Big) bool {
-		return i.ToInt().Int64() == int64(1977)
+	rpc.On("CallContext", mock.Anything, mock.Anything, "eth_getFilterChanges", mock.MatchedBy(func(f string) bool {
+		return f == "filter_id1"
 	})).Run(func(args mock.Arguments) {
 		*(args[1].(*[]*ethbinding.Hash)) = []*ethbinding.Hash{}
 	}).Return(nil)
@@ -557,10 +557,10 @@ func TestConfirmationsListenerStopStream(t *testing.T) {
 	})
 
 	rpc.On("CallContext", mock.Anything, mock.Anything, "eth_newBlockFilter").Run(func(args mock.Arguments) {
-		args[1].(*hexutil.Big).ToInt().SetString("1977", 10)
+		*args[1].(*string) = "filter_id1"
 	}).Return(nil)
-	rpc.On("CallContext", mock.Anything, mock.Anything, "eth_getFilterChanges", mock.MatchedBy(func(i hexutil.Big) bool {
-		return i.ToInt().Int64() == int64(1977)
+	rpc.On("CallContext", mock.Anything, mock.Anything, "eth_getFilterChanges", mock.MatchedBy(func(f string) bool {
+		return f == "filter_id1"
 	})).Run(func(args mock.Arguments) {
 		*(args[1].(*[]*ethbinding.Hash)) = []*ethbinding.Hash{}
 	}).Return(nil)
@@ -602,10 +602,10 @@ func TestConfirmationsRemoveEvent(t *testing.T) {
 
 	changeCount := 0
 	rpc.On("CallContext", mock.Anything, mock.Anything, "eth_newBlockFilter").Run(func(args mock.Arguments) {
-		args[1].(*hexutil.Big).ToInt().SetString("1977", 10)
+		*args[1].(*string) = "filter_id1"
 	}).Return(nil).Maybe()
-	rpc.On("CallContext", mock.Anything, mock.Anything, "eth_getFilterChanges", mock.MatchedBy(func(i hexutil.Big) bool {
-		return i.ToInt().Int64() == int64(1977)
+	rpc.On("CallContext", mock.Anything, mock.Anything, "eth_getFilterChanges", mock.MatchedBy(func(f string) bool {
+		return f == "filter_id1"
 	})).Run(func(args mock.Arguments) {
 		*(args[1].(*[]*ethbinding.Hash)) = []*ethbinding.Hash{}
 		changeCount++

--- a/internal/events/eventstream_test.go
+++ b/internal/events/eventstream_test.go
@@ -26,7 +26,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/hyperledger/firefly-ethconnect/internal/contractregistry"
 	"github.com/hyperledger/firefly-ethconnect/internal/errors"
 	"github.com/hyperledger/firefly-ethconnect/internal/eth"
@@ -108,10 +107,10 @@ func newTestStreamForConfirmations(t *testing.T) (*eventStream, func()) {
 	// Mock the RPC calls for the block confirmations manager that will just spin returning no results
 	rpc := sm.rpc.(*ethmocks.RPCClient)
 	rpc.On("CallContext", mock.Anything, mock.Anything, "eth_newBlockFilter").Run(func(args mock.Arguments) {
-		args[1].(*hexutil.Big).ToInt().SetString("1977", 10)
+		*args[1].(*string) = "filter_id1"
 	}).Return(nil).Maybe()
-	rpc.On("CallContext", mock.Anything, mock.Anything, "eth_getFilterChanges", mock.MatchedBy(func(i hexutil.Big) bool {
-		return i.ToInt().Int64() == int64(1977)
+	rpc.On("CallContext", mock.Anything, mock.Anything, "eth_getFilterChanges", mock.MatchedBy(func(f string) bool {
+		return f == "filter_id1"
 	})).Run(func(args mock.Arguments) {
 		*(args[1].(*[]*ethbinding.Hash)) = []*ethbinding.Hash{}
 	}).Return(nil).Maybe()

--- a/internal/events/subscription.go
+++ b/internal/events/subscription.go
@@ -77,7 +77,7 @@ type subscription struct {
 	cr                  contractregistry.ContractResolver
 	lp                  *logProcessor
 	logName             string
-	filterID            ethbinding.HexBigInt
+	filterID            string
 	filteredOnce        bool
 	filterStale         bool
 	deleting            bool
@@ -216,7 +216,7 @@ func (s *subscription) createFilter(ctx context.Context, since *big.Int) error {
 	s.catchupBlock = nil // we are not in catchup mode now
 	s.filteredOnce = false
 	s.markFilterStale(ctx, false)
-	log.Infof("%s: created filter from block %s: %s - %+v", s.logName, since.String(), s.filterID.String(), s.info.Filter)
+	log.Infof("%s: created filter from block %s: %s - %+v", s.logName, since.String(), s.filterID, s.info.Filter)
 	return err
 }
 


### PR DESCRIPTION
The JSON/RPC spec has previously stated that the result of an `eth_newFitler` will be a `QUANTITY`, and that is so in Besu/Go-ethereum (and derivatives). However, we've found that there are EVM chain node implementations return other values, such as a UUID encoded to a string.

EthConnect doesn't have any reason to rely on it being a numeric, as it's just an opaque value that stores and sends back on future calls.

The latest generated official docs (at the current point less detailed than the previous wiki based docs) Ethereum JSON/RPC spec docs state `string` as the result:
https://ethereum.github.io/execution-apis/api-documentation/

So this PR moves EthConnect to just use a string