### PR TITLE
Fix potential deadlock broadcasting to a closed WS connection

### DIFF
--- a/internal/ws/wsserver.go
+++ b/internal/ws/wsserver.go
@@ -223,6 +223,10 @@ func (s *webSocketServer) processReplies() {
 
 func (s *webSocketServer) broadcastToConnections(connections []*webSocketConnection, message interface{}) {
 	for _, c := range connections {
-		c.broadcast <- message
+		select {
+		case c.broadcast <- message:
+		case <-c.closing:
+			log.Warnf("Connection %s closed while attempting to deliver reply", c.id)
+		}
 	}
 }

--- a/internal/ws/wsserver_test.go
+++ b/internal/ws/wsserver_test.go
@@ -351,3 +351,20 @@ func TestSendReply(t *testing.T) {
 	c.ReadJSON(&val)
 	assert.Equal("Hello World", val)
 }
+
+func TestBroadcastClosing(t *testing.T) {
+
+	w, ts := newTestWebSocketServer()
+	defer ts.Close()
+	w.getTopic("test")
+
+	c := &webSocketConnection{
+		server:   w,
+		topics:   make(map[string]*webSocketTopic),
+		closing:  make(chan struct{}),
+		newTopic: make(chan bool),
+	}
+	close(c.closing)
+	// Check this doesn't block
+	c.server.broadcastToConnections([]*webSocketConnection{c}, "anything")
+}


### PR DESCRIPTION
Port of https://github.com/hyperledger/firefly-transaction-manager/pull/28 to EthConnect codebase, which shares this WS socket management code.