### PR TITLE
Two phase init was not passing smartContractGW to receipt store

### DIFF
--- a/cmd/ethconnect.go
+++ b/cmd/ethconnect.go
@@ -188,7 +188,7 @@ func startServer() (err error) {
 		// In this scenario, we can pass the receipt store to the Kafka bridge for it to do
 		// additional idempotency checks that prevent res-submission of transactions.
 		if idempotencyCheckReceiptStore == nil {
-			idempotencyCheckReceiptStore, err = restGateway.InitReceiptStore()
+			idempotencyCheckReceiptStore, err = restGateway.Init()
 			if err != nil {
 				return err
 			}

--- a/internal/ws/wsserver.go
+++ b/internal/ws/wsserver.go
@@ -217,6 +217,7 @@ func (s *webSocketServer) processReplies() {
 		s.mux.Lock()
 		wsconns := getConnListFromMap(s.replyMap)
 		s.mux.Unlock()
+		log.Debugf("Sending reply to %d WS connections", len(wsconns))
 		s.broadcastToConnections(wsconns, message)
 	}
 }


### PR DESCRIPTION
Which meant no WS receipts were being delivered.

This was caused by new initialization order in #227 

Found through e2e in FireFly under https://github.com/hyperledger/firefly/pull/1033