### PR TITLE
Move ABI/Contract store to LevelDB from flat files

### DIFF
--- a/internal/contractregistry/contractstore.go
+++ b/internal/contractregistry/contractstore.go
@@ -225,6 +225,8 @@ func (cs *contractStore) AddABI(abiID string, deployMsg *messages.DeployContract
 	return &storedABI.ABIInfo, nil
 }
 
+// GetLocalABIInfo retrieves just the minimal ABIInfo sub-set of the JSON fields from the contract
+// store for local ABI definitions (ones uploaded on the /abis endpoint).
 func (cs *contractStore) GetLocalABIInfo(abiID string) (info *ABIInfo, err error) {
 	return info, cs.db.GetJSON(fmt.Sprintf("%s/%s", ldbABIIDPrefix, abiID), &info)
 }
@@ -455,8 +457,8 @@ func (cs *contractStore) AddRemoteInstance(lookupStr, address string) error {
 func (cs *contractStore) ListContracts() ([]messages.TimeSortable, error) {
 	retval := make([]messages.TimeSortable, 0)
 	it := cs.db.NewIteratorWithRange(&kvstore.Range{
-		Start: []byte(ldbContractAddressPrefix + "/"),
-		Limit: []byte(ldbContractAddressPrefix + "0"),
+		Start: []byte(ldbContractAddressPrefix + "/"), // the beginning of the key sets with the `prefix/`
+		Limit: []byte(ldbContractAddressPrefix + "0"), // this is after the last key with a `prefix/` ('0' is after '/')
 	})
 	for it.Next() {
 		var info ContractInfo
@@ -474,8 +476,8 @@ func (cs *contractStore) ListContracts() ([]messages.TimeSortable, error) {
 func (cs *contractStore) ListABIs() ([]messages.TimeSortable, error) {
 	retval := make([]messages.TimeSortable, 0)
 	it := cs.db.NewIteratorWithRange(&kvstore.Range{
-		Start: []byte(ldbABIIDPrefix + "/"),
-		Limit: []byte(ldbABIIDPrefix + "0"),
+		Start: []byte(ldbABIIDPrefix + "/"), // the beginning of the key sets with the `prefix/`
+		Limit: []byte(ldbABIIDPrefix + "0"), // this is after the last key with a `prefix/` ('0' is after '/')
 	})
 	for it.Next() {
 		var info ABIInfo // we only de-serialize the ABIInfo part of the full record

--- a/internal/contractregistry/contractstore.go
+++ b/internal/contractregistry/contractstore.go
@@ -39,6 +39,8 @@ import (
 const (
 	// DefaultABICacheSize is the number of entries we will hold in a LRU cache for ABIs
 	DefaultABICacheSize = 25
+	// DefaultLevelDBName is default name of the LevelDB created in the storagePath
+	DefaultLevelDBName = "abidb"
 )
 
 type StoredABI struct {
@@ -67,6 +69,7 @@ type ContractStore interface {
 
 type ContractStoreConf struct {
 	StoragePath  string `json:"storagePath"`
+	LevelDBName  string `json:"ldbName"`
 	BaseURL      string `json:"baseURL"`
 	ABICacheSize *int   `json:"abiCacheSize"`
 }
@@ -317,7 +320,11 @@ func (cs *contractStore) Init() (err error) {
 	if cs.abiCache, err = lru.New(cacheSize); err != nil {
 		return ethconnecterrors.Errorf(ethconnecterrors.RESTGatewayResourceErr, err)
 	}
-	dbPath := path.Join(cs.conf.StoragePath, "contractsdb")
+	ldbName := cs.conf.LevelDBName
+	if ldbName != "" {
+		ldbName = DefaultLevelDBName
+	}
+	dbPath := path.Join(cs.conf.StoragePath, ldbName)
 	if cs.db, err = kvstore.NewLDBKeyValueStore(dbPath); err != nil {
 		return err
 	}

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -517,6 +517,14 @@ var (
 	ReceiptErrorIdempotencyCheck = e(100220, "Failed querying the receipt store, performing duplicate message check on ackmode=receipt for id %s: %s")
 	// ResubmissionPreventedCheckTransactionHash redelivery was prevented by the processor
 	ResubmissionPreventedCheckTransactionHash = e(100221, "Resubmission of this transaction was prevented by the REST API Gateway. Check the status of the transaction by the transaction hash")
+
+	// KVStoreDBMarshal failed to unmarshal to object
+	KVStoreDBMarshal = e(100222, "Failed to serialize JSON to %T: %s")
+	// KVStoreDBUnmarshal failed to unmarshal to object
+	KVStoreDBUnmarshal = e(100223, "Failed to parse stored JSON at %T: %s")
+
+	// RESTGatewayMissingStoragePath storage path must be set
+	RESTGatewayMissingStoragePath = e(100224, "REST Gateway storagePath must be set")
 )
 
 type EthconnectError interface {

--- a/internal/kvstore/memkv.go
+++ b/internal/kvstore/memkv.go
@@ -15,6 +15,8 @@
 package kvstore
 
 import (
+	"encoding/json"
+
 	"github.com/syndtr/goleveldb/leveldb"
 )
 
@@ -32,6 +34,15 @@ func (m *MockKV) Put(key string, val []byte) error {
 	return m.StoreErr
 }
 
+// PutJSON an object
+func (m *MockKV) PutJSON(key string, obj interface{}) error {
+	b, err := json.Marshal(obj)
+	if err != nil {
+		return err
+	}
+	return m.Put(key, b)
+}
+
 // Get a key
 func (m *MockKV) Get(key string) ([]byte, error) {
 	v, exists := m.KVS[key]
@@ -39,6 +50,15 @@ func (m *MockKV) Get(key string) ([]byte, error) {
 		return nil, leveldb.ErrNotFound
 	}
 	return v, m.LoadErr
+}
+
+// Get a key as object
+func (m *MockKV) GetJSON(key string, obj interface{}) error {
+	b, err := m.Get(key)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(b, obj)
 }
 
 // Delete a key
@@ -53,7 +73,7 @@ func (m *MockKV) NewIterator() KVIterator {
 }
 
 // NewIterator for a new iterator
-func (m *MockKV) NewIteratorWithRange(rng interface{}) KVIterator {
+func (m *MockKV) NewIteratorWithRange(rng *Range) KVIterator {
 	return nil // not implemented in mock
 }
 

--- a/internal/kvstore/memkv_test.go
+++ b/internal/kvstore/memkv_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/syndtr/goleveldb/leveldb/util"
 )
 
 func TestExerciseMockLDB(t *testing.T) {
@@ -31,7 +32,34 @@ func TestExerciseMockLDB(t *testing.T) {
 	m.Delete("test")
 	_, err := m.Get("test")
 	assert.Regexp("leveldb: not found", err)
-	m.NewIterator()
+
+	type myType struct {
+		Value string
+	}
+	err = m.PutJSON("mykey", &myType{Value: "something"})
+	assert.NoError(err)
+	var retObj myType
+	err = m.GetJSON("mykey", &retObj)
+	assert.NoError(err)
+	assert.Equal("something", retObj.Value)
+
+	err = m.PutJSON("mykey", map[bool]bool{false: true})
+	assert.Error(err)
+
+	err = m.GetJSON("mykey", map[bool]bool{false: true})
+	assert.Error(err)
+
+	err = m.GetJSON("not found", map[bool]bool{false: true})
+	assert.Equal(ErrorNotFound, err)
+
+	assert.Nil(m.NewIterator())
+	assert.Nil(m.NewIteratorWithRange(&util.Range{}))
 	m.Close()
 
+}
+
+func TestMockKV(t *testing.T) {
+	var kv KVStore
+	kv = NewMockKV(nil)
+	assert.NotNil(t, kv)
 }

--- a/internal/receipts/leveldbreceipt_test.go
+++ b/internal/receipts/leveldbreceipt_test.go
@@ -47,7 +47,13 @@ func (m *mockKVStore) Get(key string) ([]byte, error) {
 	}
 	return m.getVal, m.err
 }
+func (m *mockKVStore) GetJSON(key string, obj interface{}) error {
+	return m.err
+}
 func (m *mockKVStore) Put(key string, val []byte) error {
+	return m.err
+}
+func (m *mockKVStore) PutJSON(key string, val interface{}) error {
 	return m.err
 }
 func (m *mockKVStore) Delete(key string) error {
@@ -56,7 +62,7 @@ func (m *mockKVStore) Delete(key string) error {
 func (m *mockKVStore) NewIterator() kvstore.KVIterator {
 	return nil
 }
-func (m *mockKVStore) NewIteratorWithRange(keyRange interface{}) kvstore.KVIterator {
+func (m *mockKVStore) NewIteratorWithRange(keyRange *kvstore.Range) kvstore.KVIterator {
 	return nil
 }
 

--- a/internal/rest/restgateway.go
+++ b/internal/rest/restgateway.go
@@ -302,6 +302,7 @@ func (g *RESTGateway) Start() (err error) {
 	// Check we're initialized (caller can choose to call init explicitly)
 	if g.receipts == nil {
 		if _, err = g.Init(); err != nil {
+			log.Errorf("Failed to initialize: %s", err)
 			return err
 		}
 	}

--- a/internal/rest/restgateway_test.go
+++ b/internal/rest/restgateway_test.go
@@ -18,9 +18,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"sync"
 	"testing"
 	"time"
@@ -115,6 +117,8 @@ func TestStartStatusStopNoKafkaWebhooksAccessToken(t *testing.T) {
 
 func TestStartStatusStopNoKafkaWebhooksMissingToken(t *testing.T) {
 	assert := assert.New(t)
+	dir, _ := ioutil.TempDir("", "fly")
+	defer os.RemoveAll(dir)
 
 	auth.RegisterSecurityModule(&authtest.TestSecurityModule{})
 
@@ -129,7 +133,7 @@ func TestStartStatusStopNoKafkaWebhooksMissingToken(t *testing.T) {
 	g.conf.HTTP.Port = lastPort
 	g.conf.HTTP.LocalAddr = "127.0.0.1"
 	g.conf.RPC.URL = u.String()
-	g.conf.OpenAPI.StoragePath = "/tmp/t"
+	g.conf.OpenAPI.StoragePath = dir
 	lastPort++
 	var err error
 	var wg sync.WaitGroup
@@ -141,8 +145,8 @@ func TestStartStatusStopNoKafkaWebhooksMissingToken(t *testing.T) {
 
 	url, _ := url.Parse(fmt.Sprintf("http://localhost:%d/status", g.conf.HTTP.Port))
 	var resp *http.Response
-	for i := 0; i < 5; i++ {
-		time.Sleep(200 * time.Millisecond)
+	for i := 0; i < 10; i++ {
+		time.Sleep(100 * time.Millisecond)
 		req := &http.Request{URL: url, Method: http.MethodGet, Header: http.Header{
 			"authorization": []string{"bearer"},
 		}}

--- a/mocks/contractregistrymocks/contract_store.go
+++ b/mocks/contractregistrymocks/contract_store.go
@@ -17,7 +17,7 @@ type ContractStore struct {
 }
 
 // AddABI provides a mock function with given fields: id, deployMsg, createdTime
-func (_m *ContractStore) AddABI(id string, deployMsg *messages.DeployContract, createdTime time.Time) *contractregistry.ABIInfo {
+func (_m *ContractStore) AddABI(id string, deployMsg *messages.DeployContract, createdTime time.Time) (*contractregistry.ABIInfo, error) {
 	ret := _m.Called(id, deployMsg, createdTime)
 
 	var r0 *contractregistry.ABIInfo
@@ -29,7 +29,14 @@ func (_m *ContractStore) AddABI(id string, deployMsg *messages.DeployContract, c
 		}
 	}
 
-	return r0
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string, *messages.DeployContract, time.Time) error); ok {
+		r1 = rf(id, deployMsg, createdTime)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }
 
 // AddContract provides a mock function with given fields: addrHexNo0x, abiID, pathName, registerAs
@@ -172,7 +179,7 @@ func (_m *ContractStore) Init() error {
 }
 
 // ListABIs provides a mock function with given fields:
-func (_m *ContractStore) ListABIs() []messages.TimeSortable {
+func (_m *ContractStore) ListABIs() ([]messages.TimeSortable, error) {
 	ret := _m.Called()
 
 	var r0 []messages.TimeSortable
@@ -184,11 +191,18 @@ func (_m *ContractStore) ListABIs() []messages.TimeSortable {
 		}
 	}
 
-	return r0
+	var r1 error
+	if rf, ok := ret.Get(1).(func() error); ok {
+		r1 = rf()
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }
 
 // ListContracts provides a mock function with given fields:
-func (_m *ContractStore) ListContracts() []messages.TimeSortable {
+func (_m *ContractStore) ListContracts() ([]messages.TimeSortable, error) {
 	ret := _m.Called()
 
 	var r0 []messages.TimeSortable
@@ -200,7 +214,14 @@ func (_m *ContractStore) ListContracts() []messages.TimeSortable {
 		}
 	}
 
-	return r0
+	var r1 error
+	if rf, ok := ret.Get(1).(func() error); ok {
+		r1 = rf()
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }
 
 // ResolveContractAddress provides a mock function with given fields: registeredName


### PR DESCRIPTION
In the case where you deploy many contracts (hundreds of thousands for example), the flat file based store of contract ABIs/registrations becomes inefficient. This affects startup time and memory usage.

This PR is to make this storage consistent with elsewhere in the codebase, and use LevelDB rather than flat files.