### PR TITLE
Differentiate bytes vs. fixed bytes in encoding parameters

### DIFF
--- a/internal/eth/txn.go
+++ b/internal/eth/txn.go
@@ -654,7 +654,11 @@ func (tx *Txn) generateTypedArg(requiredType *ethbinding.ABIType, param interfac
 			return nil, errors.Errorf(errors.TransactionSendInputTypeBadJSONTypeForBytes, methodName, path, requiredType, suppliedType)
 		}
 		if len(bSlice) == 0 {
-			return [0]byte{}, nil
+			if requiredType.T == ethbinding.BytesTy {
+				return []byte{}, nil
+			} else {
+				return [0]byte{}, nil
+			}
 		} else if requiredType.GetType().Kind() == reflect.Array {
 			// Create ourselves an array of the right size (ethereum won't accept a slice)
 			bArrayType := reflect.ArrayOf(len(bSlice), reflect.TypeOf(bSlice[0]))

--- a/internal/eth/txn_test.go
+++ b/internal/eth/txn_test.go
@@ -1470,6 +1470,54 @@ func TestSendTxnPackError(t *testing.T) {
 	assert.Regexp("cannot use \\[0\\]uint8 as type \\[1\\]uint8 as argument", err.Error())
 }
 
+func TestSendTxnPackEmptyBytes(t *testing.T) {
+	assert := assert.New(t)
+
+	var msg messages.SendTransaction
+	msg.Parameters = []interface{}{"0x"}
+	msg.Method = &ethbinding.ABIElementMarshaling{
+		Name: "testFunc",
+		Inputs: []ethbinding.ABIArgumentMarshaling{
+			{
+				Name: "param1",
+				Type: "bytes",
+			},
+		},
+		Outputs: []ethbinding.ABIArgumentMarshaling{
+			{
+				Name: "ret1",
+				Type: "uint256",
+			},
+		},
+	}
+	_, err := NewSendTxn(&msg, nil)
+	assert.NoError(err)
+}
+
+func TestSendTxnPackBytes(t *testing.T) {
+	assert := assert.New(t)
+
+	var msg messages.SendTransaction
+	msg.Parameters = []interface{}{"0x1234"}
+	msg.Method = &ethbinding.ABIElementMarshaling{
+		Name: "testFunc",
+		Inputs: []ethbinding.ABIArgumentMarshaling{
+			{
+				Name: "param1",
+				Type: "bytes2",
+			},
+		},
+		Outputs: []ethbinding.ABIArgumentMarshaling{
+			{
+				Name: "ret1",
+				Type: "uint256",
+			},
+		},
+	}
+	_, err := NewSendTxn(&msg, nil)
+	assert.NoError(err)
+}
+
 func TestProcessRLPBytesValidTypes(t *testing.T) {
 	assert := assert.New(t)
 


### PR DESCRIPTION
fixes https://github.com/hyperledger/firefly-ethconnect/issues/133

for a `bytes` parameter, to input an empty value, `0x` is the expected value. It fails the packing step and returns the error as described in the issue above.

This fixes that issue by differentiating bytes vs. fixed length bytes, and returns a slice vs. fixed length array respectively