### PR TITLE
Add synchronized flag to subscriptions

### DIFF
--- a/internal/events/subscription.go
+++ b/internal/events/subscription.go
@@ -59,15 +59,16 @@ type ABIRefOrInline struct {
 // SubscriptionInfo is the persisted data for the subscription
 type SubscriptionInfo struct {
 	messages.TimeSorted
-	ID        string                           `json:"id,omitempty"`
-	Path      string                           `json:"path"`
-	Summary   string                           `json:"-"`    // System generated name for the subscription
-	Name      string                           `json:"name"` // User provided name for the subscription, set to Summary if missing
-	Stream    string                           `json:"stream"`
-	Filter    persistedFilter                  `json:"filter"`
-	Event     *ethbinding.ABIElementMarshaling `json:"event"`
-	FromBlock string                           `json:"fromBlock,omitempty"`
-	ABI       *ABIRefOrInline                  `json:"abi,omitempty"`
+	ID           string                           `json:"id,omitempty"`
+	Path         string                           `json:"path"`
+	Summary      string                           `json:"-"`    // System generated name for the subscription
+	Name         string                           `json:"name"` // User provided name for the subscription, set to Summary if missing
+	Stream       string                           `json:"stream"`
+	Filter       persistedFilter                  `json:"filter"`
+	Event        *ethbinding.ABIElementMarshaling `json:"event"`
+	FromBlock    string                           `json:"fromBlock,omitempty"`
+	ABI          *ABIRefOrInline                  `json:"abi,omitempty"`
+	Synchronized bool                             `json:"synchronized"`
 }
 
 // subscription is the runtime that manages the subscription
@@ -214,6 +215,7 @@ func (s *subscription) createFilter(ctx context.Context, since *big.Int) error {
 		return errors.Errorf(errors.RPCCallReturnedError, "eth_newFilter", err)
 	}
 	s.catchupBlock = nil // we are not in catchup mode now
+	s.info.Synchronized = true
 	s.filteredOnce = false
 	s.markFilterStale(ctx, false)
 	log.Infof("%s: created filter from block %s: %s - %+v", s.logName, since.String(), s.filterID, s.info.Filter)
@@ -241,6 +243,7 @@ func (s *subscription) restartFilter(ctx context.Context, checkpoint *big.Int) e
 	log.Debugf("%s: new filter. Head=%s Position=%s Gap=%d (catchup threshold: %d)", s.logName, blockNumber.ToInt().String(), since.String(), blockGap, s.catchupModeBlockGap)
 	if s.catchupModeBlockGap > 0 && blockGap > s.catchupModeBlockGap {
 		s.catchupBlock = since // note if we were already in catchup, this does not change anything
+		s.info.Synchronized = false
 		return nil
 	}
 
@@ -402,6 +405,7 @@ func (s *subscription) markFilterStale(ctx context.Context, newFilterStale bool)
 		log.Infof("%s: Uninstalled filter. ok=%t (%s)", s.logName, retval, err)
 		// Clear any catchup mode state. We will restart from the last checkpoint
 		s.catchupBlock = nil
+		s.info.Synchronized = false
 	}
 	s.filterStale = newFilterStale
 }

--- a/internal/events/subscription.go
+++ b/internal/events/subscription.go
@@ -215,7 +215,6 @@ func (s *subscription) createFilter(ctx context.Context, since *big.Int) error {
 		return errors.Errorf(errors.RPCCallReturnedError, "eth_newFilter", err)
 	}
 	s.catchupBlock = nil // we are not in catchup mode now
-	s.info.Synchronized = true
 	s.filteredOnce = false
 	s.markFilterStale(ctx, false)
 	log.Infof("%s: created filter from block %s: %s - %+v", s.logName, since.String(), s.filterID, s.info.Filter)
@@ -362,6 +361,7 @@ func (s *subscription) processNewEvents(ctx context.Context) error {
 	rpcMethod := "eth_getFilterLogs"
 	if s.filteredOnce {
 		rpcMethod = "eth_getFilterChanges"
+		s.info.Synchronized = true
 	}
 	if err := s.rpc.CallContext(ctx, &logs, rpcMethod, s.filterID); err != nil {
 		if strings.Contains(err.Error(), "filter not found") {

--- a/internal/events/subscription_test.go
+++ b/internal/events/subscription_test.go
@@ -140,6 +140,7 @@ func TestCreateWebhookSubWithAddr(t *testing.T) {
 	assert.Equal("0x81b7baac232325e8fb0e2446cc62852d9f68c86874699311b99ef89d8ed424dd", s.info.Filter.Topics[0][0].Hex())
 	assert.Equal("0x0123456789abcDEF0123456789abCDef01234567:devcon()", s.info.Summary)
 	assert.Equal("mySubscription", s.info.Name)
+	assert.False(s.info.Synchronized)
 }
 
 func TestCreateSubscriptionNoEvent(t *testing.T) {
@@ -195,7 +196,7 @@ func TestProcessEventsStaleFilter(t *testing.T) {
 	rpc.On("CallContext", mock.Anything, mock.Anything, "eth_getFilterLogs", mock.Anything).
 		Return(fmt.Errorf("filter not found"))
 	rpc.On("CallContext", mock.Anything, mock.Anything, "eth_uninstallFilter", mock.Anything).Return(nil)
-	s := &subscription{rpc: rpc}
+	s := &subscription{rpc: rpc, info: &SubscriptionInfo{}}
 	err := s.processNewEvents(context.Background())
 	assert.Regexp("filter not found", err)
 	assert.True(s.filterStale)
@@ -331,7 +332,8 @@ func TestUnsubscribe(t *testing.T) {
 	rpc.On("CallContext", mock.Anything, mock.Anything, "eth_uninstallFilter", mock.Anything).
 		Return(fmt.Errorf("pop"))
 	s := &subscription{
-		rpc: rpc,
+		rpc:  rpc,
+		info: &SubscriptionInfo{},
 	}
 	err := s.unsubscribe(context.Background(), true)
 	assert.NoError(err)


### PR DESCRIPTION
This PR adds a new flag to a subscription to indicate whether ETHConnect is still catching up or has caught up to the configured block height gap, and is keeping up with the chain head. When you do a `GET` on a subscription you will now see a `synchronized` field like this:

```json
    {
        "created": "2023-07-24T17:02:29Z",
        "id": "sb-6e37fa9f-1a8c-48e1-6159-0f15701e15e5",
        "path": "/subscriptions/sb-6e37fa9f-1a8c-48e1-6159-0f15701e15e5",
        "name": "default_BatchPin_3078626437333333",
        "stream": "es-900f1d84-22fd-470f-54cd-b87d3e9e475a",
        "filter": {
            "address": [
                "0xbd7333f75351fe1bfc0e6f0bf2c01fc185beaf4a"
            ],
            "topics": [
                [
                    "0x805721bc246bccc732581be0c0aa2dd8f7ec93e97ba4b307be84428c98b0a12f"
                ]
            ]
        },
        "event": {
            "type": "event",
            "name": "BatchPin",
            "inputs": [
                {
                    "name": "author",
                    "type": "address",
                    "internalType": "address"
                },
                {
                    "name": "timestamp",
                    "type": "uint256",
                    "internalType": "uint256"
                },
                {
                    "name": "namespace",
                    "type": "string",
                    "internalType": "string"
                },
                {
                    "name": "uuids",
                    "type": "bytes32",
                    "internalType": "bytes32"
                },
                {
                    "name": "batchHash",
                    "type": "bytes32",
                    "internalType": "bytes32"
                },
                {
                    "name": "payloadRef",
                    "type": "string",
                    "internalType": "string"
                },
                {
                    "name": "contexts",
                    "type": "bytes32[]",
                    "internalType": "bytes32[]"
                }
            ],
            "outputs": null
        },
        "fromBlock": "latest",
        "synchronized": true
    }
```