### PR TITLE
Added priv_call functionality to generated contract APIs

### DIFF
--- a/internal/eth/send.go
+++ b/internal/eth/send.go
@@ -95,8 +95,16 @@ func (tx *Txn) Call(ctx context.Context, rpc RPCClient, blocknumber string) (res
 	defer cancel()
 
 	var hexString string
-	if err = rpc.CallContext(ctx, &hexString, "eth_call", txArgs, blocknumber); err != nil {
-		return nil, false, errors.Errorf(errors.TransactionSendCallFailedNoRevert, err)
+	if tx.PrivacyGroupID != "" {
+		// PrivacyGroupID is mandatory for a priv_call, so user is expected to pass exactly this key.
+		// No generation of PrivacyGroupID based on PrivateFrom and PrivateFor is implemented because of this.
+		if err = rpc.CallContext(ctx, &hexString, "priv_call", tx.PrivacyGroupID, txArgs, blocknumber); err != nil {
+			return nil, false, errors.Errorf(errors.TransactionSendCallFailedNoRevert, err)
+		}
+	} else {
+		if err = rpc.CallContext(ctx, &hexString, "eth_call", txArgs, blocknumber); err != nil {
+			return nil, false, errors.Errorf(errors.TransactionSendCallFailedNoRevert, err)
+		}
 	}
 	if len(hexString) == 0 || hexString == "0x" {
 		return nil, false, nil

--- a/internal/eth/txn.go
+++ b/internal/eth/txn.go
@@ -352,6 +352,7 @@ func NewSendTxn(msg *messages.SendTransaction, signer TXSigner) (tx *Txn, err er
 	// retain private transaction fields
 	tx.PrivateFrom = msg.PrivateFrom
 	tx.PrivateFor = msg.PrivateFor
+	tx.PrivacyGroupID = msg.PrivacyGroupID
 	return
 }
 


### PR DESCRIPTION
- Retain PrivacyGroupID together with other private transaction fields
- Switch to priv_call when PrivacyGroupID is passed as query option
- No  PrivacyGroupID generation from PrivateFrom and PrivateFor