### PR TITLE
Mark filter stale for Besu nodes

### DIFF
--- a/internal/events/block_confirmations.go
+++ b/internal/events/block_confirmations.go
@@ -202,7 +202,7 @@ func (bcm *blockConfirmationManager) pollBlockFilter() ([]*ethbinding.Hash, erro
 	defer cancel()
 	var blockHashes []*ethbinding.Hash
 	if err := bcm.rpc.CallContext(ctx, &blockHashes, "eth_getFilterChanges", bcm.filterID); err != nil {
-		if strings.Contains(err.Error(), "filter not found") {
+		if strings.Contains(strings.ToLower(err.Error()), "filter not found") {
 			bcm.filterStale = true
 		}
 		return nil, err

--- a/internal/events/subscription.go
+++ b/internal/events/subscription.go
@@ -364,7 +364,7 @@ func (s *subscription) processNewEvents(ctx context.Context) error {
 		s.info.Synchronized = true
 	}
 	if err := s.rpc.CallContext(ctx, &logs, rpcMethod, s.filterID); err != nil {
-		if strings.Contains(err.Error(), "filter not found") {
+		if strings.Contains(strings.ToLower(err.Error()), "filter not found") {
 			s.markFilterStale(ctx, true)
 		}
 		return err


### PR DESCRIPTION
Not all Ethereum nodes return exactly the same error message when a filter does not exist. This caused ETHConnect to not be able to recreate a filter automatically in some cases, for example if a Besu node was restarted. This would result in log messages like:

```
[2023-10-19T06:50:07.739Z] ERROR es-1fb7a291-487f-404b-44ab-0a36a0da4dae: subscription error: Filter not found
```

This PR fixes this issue to make ETHConnect a bit more flexible to be able to recreate the filter automatically in this case.