### PR TITLE
[subscriptions] Fix for Validating URLs

### DIFF
--- a/internal/events/eventstream.go
+++ b/internal/events/eventstream.go
@@ -764,7 +764,8 @@ func (a *eventStream) performActionWithRetry(batchNumber uint64, events []*event
 func (a *eventStream) isAddressUnsafe(ip *net.IPAddr) bool {
 	ip4 := ip.IP.To4()
 	return !a.allowPrivateIPs &&
-		(ip4[0] == 0 ||
+		(len(ip4) < 1 ||
+			ip4[0] == 0 ||
 			ip4[0] >= 224 ||
 			ip4[0] == 127 ||
 			ip4[0] == 10 ||

--- a/internal/events/webhooks_test.go
+++ b/internal/events/webhooks_test.go
@@ -7,7 +7,9 @@ import (
 
 func TestValidateURL(t *testing.T) {
   w := &webhookAction{
-    es: nil,
+    es: &eventStream{
+      allowPrivateIPs: false,
+    },
     spec: &webhookActionInfo{
       URL: "badurl",
     },

--- a/internal/events/webhooks_test.go
+++ b/internal/events/webhooks_test.go
@@ -1,0 +1,22 @@
+package events
+
+import (
+  "github.com/stretchr/testify/assert"
+  "testing"
+)
+
+func TestValidateURL(t *testing.T) {
+  w := &webhookAction{
+    es: nil,
+    spec: &webhookActionInfo{
+      URL: "badurl",
+    },
+  }
+
+  _, _, err := w.validateURL()
+  assert.Error(t, err)
+
+  w.spec.URL = "https://google.com"
+  _, _, err = w.validateURL()
+  assert.NoError(t, err)
+}


### PR DESCRIPTION
We've observed a webhook subscription can be configured with URL which resolves an empty address (without throwing earlier errors):
```
panic: runtime error: index out of range [0] with length 0

goroutine 66 [running]:
github.com/hyperledger/firefly-ethconnect/internal/events.(*eventStream).isAddressUnsafe(0x11c4458, 0x1217e18)
	/kaleido-io/ethconnect/internal/events/eventstream.go:767 +0xd4
```

This is meant to treat this edge case then as an "unsafe address" so Ethconnect does not 1) panic and 2) the URL / hostname will be bubbled up as an error.