### PR TITLE
Fix image not found issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM golang:1.21-buster AS builder
+FROM golang:1.21-alpine3.19 AS builder
+RUN apk add make
 WORKDIR /ethconnect
 RUN apt-get update -y \
     && apt-get install -y build-essential git \


### PR DESCRIPTION
There is an issue with building docker
`ERROR: failed to solve: golang:1.21-buster: docker.io/library/golang:1.21-buster: not found`

https://github.com/hyperledger/firefly-ethconnect/actions/runs/7579131739/job/20642836640

Fixed it by using 1.21-alpine3.19 as for example for https://github.com/hyperledger/firefly-tezosconnect/pull/34