### PR TITLE
Fix docker build and add to PR checks

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -37,3 +37,10 @@ jobs:
 
       - name: Upload coverage
         run: bash <(curl -s https://codecov.io/bash)
+
+  docker-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build
+        run: docker build .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-FROM golang:1.21-alpine3.19 AS builder
-RUN apk add make
+FROM golang:1.21-bullseye AS builder
 WORKDIR /ethconnect
 RUN apt-get update -y \
     && apt-get install -y build-essential git \
@@ -14,7 +13,7 @@ ADD . .
 RUN cp go.mod.new go.mod
 RUN make clean deps build
 
-FROM debian:buster-slim
+FROM debian:bullseye-slim
 WORKDIR /ethconnect
 COPY --from=builder /ethconnect/ethconnect .
 COPY --from=builder /ethconnect/ethbinding.so .


### PR DESCRIPTION
These changes fix a couple issue with the Dockerfile. They also add the docker build to the PR checks so we don't end up merging something that means we can't build images anymore.