### PR TITLE
Chore/relax go 1.26

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -22,8 +22,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: "1.26.4"
-          check-latest: true
+          go-version: "1.26"
 
       - name: Install solc
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.4-bookworm AS builder
+FROM golang:1.26-bookworm AS builder
 WORKDIR /ethconnect
 RUN apt-get update -y \
     && apt-get install -y build-essential git \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hyperledger-firefly/ethconnect
 
-go 1.26.4
+go 1.26.0
 
 require (
 	github.com/IBM/sarama v1.42.1

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/hyperledger-firefly/ethconnect
 
 go 1.26.0
 
+toolchain go1.26.4
+
 require (
 	github.com/IBM/sarama v1.42.1
 	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751


### PR DESCRIPTION
Loosen the pinned Go version from 1.26.4 to the 1.26 minor line
across go.mod, the Dockerfile builder image, and the CI workflow.

Min go version is 1.26.0